### PR TITLE
Configure CodeRabbit reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+tone_instructions: "Be concise and direct. Prioritize correctness, safety, Windows PowerShell 5.1 compatibility, and user-impacting behavior over style nits."
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  review_status: true
+  review_details: true
+  poem: false
+  auto_review:
+    enabled: true
+    drafts: false
+    auto_incremental_review: true
+  path_instructions:
+    - path: "Invoke-BraveDebloat.ps1"
+      instructions: "Focus on Windows PowerShell 5.1 compatibility, ShouldProcess and WhatIf behavior, registry safety, backup and restore behavior, profile JSON writes, and dry-run clarity. Avoid cosmetic style comments unless they affect safety or readability."
+    - path: "config/policies.json"
+      instructions: "Verify policy names, preset inheritance, feature mappings, and safety blocks. Pay special attention to anything that could disable Brave Shields, weaken Safe Browsing, disable updates, or make profile cleanup too broad."
+    - path: "scripts/*.ps1"
+      instructions: "Check that tests cover manifest integrity, feature toggles, restore validation, dry-run behavior, and Windows PowerShell 5.1 compatibility."
+    - path: ".github/workflows/*.yml"
+      instructions: "Check that CI still validates both PowerShell 7 and Windows PowerShell 5.1 paths."
+
+chat:
+  auto_reply: true

--- a/README.md
+++ b/README.md
@@ -154,3 +154,7 @@ Run the built-in manifest and syntax checks:
 .\scripts\Test-PolicyManifest.ps1
 .\scripts\Test-Behavior.ps1
 ```
+
+## Pull Request Review
+
+Pull requests are configured for CodeRabbit review with repo-specific guidance in `.coderabbit.yaml`. Reviews should focus on PowerShell 5.1 compatibility, registry safety, backup/restore behavior, policy manifest integrity, and dry-run clarity.


### PR DESCRIPTION
## Summary

- Add `.coderabbit.yaml` with repo-specific review guidance.
- Document CodeRabbit-focused PR review expectations in the README.

## Why

This gives CodeRabbit an open pull request to review and helps steer future reviews toward BraveDebloater's actual risk areas: Windows PowerShell 5.1 compatibility, registry safety, backup and restore behavior, policy manifest integrity, and dry-run clarity.

## Validation

- `./scripts/Test-PolicyManifest.ps1`
- `./scripts/Test-Behavior.ps1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with pull request review guidelines.

* **Chores**
  * Configured CodeRabbit review settings to support the development workflow.

---

**No user-facing changes in this release.**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->