### PR TITLE
Add exact feature selection mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added `-OnlyFeature` for running exactly selected feature cleanups without starting from a preset.
+
 ## 0.2.0 - 2026-05-04
 
 - Added friendly `Standard`, `High`, and `Extreme` presets while keeping the original preset names as aliases.

--- a/Invoke-BraveDebloat.ps1
+++ b/Invoke-BraveDebloat.ps1
@@ -985,6 +985,10 @@ $normalizedOnlyFeature = @(Normalize-FeatureNames -Names $OnlyFeature)
 $normalizedIncludeFeature = @(Normalize-FeatureNames -Names $IncludeFeature)
 $normalizedExcludeFeature = @(Normalize-FeatureNames -Names $ExcludeFeature)
 
+if ($PSBoundParameters.ContainsKey('OnlyFeature') -and $normalizedOnlyFeature.Count -eq 0) {
+    throw 'Specified -OnlyFeature contains only blank entries; please provide a valid feature name.'
+}
+
 Assert-FeatureNames -Names $normalizedIncludeFeature -FeatureMap $featureMap
 Assert-FeatureNames -Names $normalizedExcludeFeature -FeatureMap $featureMap
 Assert-FeatureNames -Names $normalizedOnlyFeature -FeatureMap $featureMap

--- a/Invoke-BraveDebloat.ps1
+++ b/Invoke-BraveDebloat.ps1
@@ -196,6 +196,20 @@ function Assert-FeatureNames {
     }
 }
 
+function Normalize-FeatureNames {
+    param([string[]]$Names)
+
+    $normalized = New-Object System.Collections.Generic.List[string]
+    foreach ($name in @($Names)) {
+        $trimmed = ([string]$name).Trim()
+        if ([string]::IsNullOrWhiteSpace($trimmed)) {
+            continue
+        }
+        Add-StringIfMissing -List $normalized -Value $trimmed
+    }
+    return $normalized.ToArray()
+}
+
 function Assert-FeatureReferences {
     param(
         [object[]]$Features,
@@ -967,17 +981,21 @@ $features = @($manifest.features)
 $featureMap = Get-FeatureMap -Features $features
 Assert-FeatureReferences -Features $features -PolicyDefinitions $policyDefinitions
 
-Assert-FeatureNames -Names $IncludeFeature -FeatureMap $featureMap
-Assert-FeatureNames -Names $ExcludeFeature -FeatureMap $featureMap
-Assert-FeatureNames -Names $OnlyFeature -FeatureMap $featureMap
-foreach ($featureName in @($IncludeFeature)) {
-    if (@($ExcludeFeature) -contains $featureName) {
+$normalizedOnlyFeature = @(Normalize-FeatureNames -Names $OnlyFeature)
+$normalizedIncludeFeature = @(Normalize-FeatureNames -Names $IncludeFeature)
+$normalizedExcludeFeature = @(Normalize-FeatureNames -Names $ExcludeFeature)
+
+Assert-FeatureNames -Names $normalizedIncludeFeature -FeatureMap $featureMap
+Assert-FeatureNames -Names $normalizedExcludeFeature -FeatureMap $featureMap
+Assert-FeatureNames -Names $normalizedOnlyFeature -FeatureMap $featureMap
+foreach ($featureName in $normalizedIncludeFeature) {
+    if ($normalizedExcludeFeature -contains $featureName) {
         throw "Feature '$featureName' cannot be both included and excluded."
     }
 }
 
-$onlyFeatureMode = @($OnlyFeature).Count -gt 0
-if ($onlyFeatureMode -and ($Customize -or @($IncludeFeature).Count -gt 0 -or @($ExcludeFeature).Count -gt 0)) {
+$onlyFeatureMode = $normalizedOnlyFeature.Count -gt 0
+if ($onlyFeatureMode -and ($Customize -or $normalizedIncludeFeature.Count -gt 0 -or $normalizedExcludeFeature.Count -gt 0)) {
     throw '-OnlyFeature cannot be combined with -Customize, -IncludeFeature, or -ExcludeFeature.'
 }
 
@@ -989,10 +1007,10 @@ if (-not $onlyFeatureMode) {
     }
 }
 
-$customFeatureRequested = $onlyFeatureMode -or $Customize -or @($IncludeFeature).Count -gt 0 -or @($ExcludeFeature).Count -gt 0
+$customFeatureRequested = $onlyFeatureMode -or $Customize -or $normalizedIncludeFeature.Count -gt 0 -or $normalizedExcludeFeature.Count -gt 0
 $featurePresetName = if ($onlyFeatureMode) { '__OnlyFeature' } else { $Preset }
-$featureIncludeNames = if ($onlyFeatureMode) { $OnlyFeature } else { $IncludeFeature }
-$featureExcludeNames = if ($onlyFeatureMode) { @() } else { $ExcludeFeature }
+$featureIncludeNames = if ($onlyFeatureMode) { $normalizedOnlyFeature } else { $normalizedIncludeFeature }
+$featureExcludeNames = if ($onlyFeatureMode) { @() } else { $normalizedExcludeFeature }
 $selectedFeatureIds = @(Resolve-FeatureSelection -Features $features -FeatureMap $featureMap -PolicyNames $policyNames -PresetName $featurePresetName -IncludeNames $featureIncludeNames -ExcludeNames $featureExcludeNames -UsePrompt:$Customize)
 
 if ($LockShields) {

--- a/Invoke-BraveDebloat.ps1
+++ b/Invoke-BraveDebloat.ps1
@@ -13,6 +13,8 @@ param(
 
     [switch]$Customize,
 
+    [string[]]$OnlyFeature = @(),
+
     [string[]]$IncludeFeature = @(),
 
     [string[]]$ExcludeFeature = @(),
@@ -184,6 +186,9 @@ function Assert-FeatureNames {
     )
 
     foreach ($name in @($Names)) {
+        if ([string]::IsNullOrWhiteSpace([string]$name)) {
+            continue
+        }
         if (-not $FeatureMap.ContainsKey($name)) {
             $available = ($FeatureMap.Keys | Sort-Object) -join ', '
             throw "Unknown feature '$name'. Available features: $available"
@@ -277,10 +282,16 @@ function Resolve-FeatureSelection {
     }
 
     foreach ($featureName in @($IncludeNames)) {
+        if ([string]::IsNullOrWhiteSpace([string]$featureName)) {
+            continue
+        }
         Set-FeatureSelection -Feature $FeatureMap[$featureName] -PolicyNames $PolicyNames -SelectedFeatureIds $selectedFeatureIds -Selected:$true
     }
 
     foreach ($featureName in @($ExcludeNames)) {
+        if ([string]::IsNullOrWhiteSpace([string]$featureName)) {
+            continue
+        }
         Set-FeatureSelection -Feature $FeatureMap[$featureName] -PolicyNames $PolicyNames -SelectedFeatureIds $selectedFeatureIds -Selected:$false
     }
 
@@ -958,20 +969,31 @@ Assert-FeatureReferences -Features $features -PolicyDefinitions $policyDefinitio
 
 Assert-FeatureNames -Names $IncludeFeature -FeatureMap $featureMap
 Assert-FeatureNames -Names $ExcludeFeature -FeatureMap $featureMap
+Assert-FeatureNames -Names $OnlyFeature -FeatureMap $featureMap
 foreach ($featureName in @($IncludeFeature)) {
     if (@($ExcludeFeature) -contains $featureName) {
         throw "Feature '$featureName' cannot be both included and excluded."
     }
 }
 
-$policyNames = New-Object System.Collections.Generic.List[string]
-
-foreach ($name in Resolve-PresetPolicies -Name $Preset -Presets $presets) {
-    [void]$policyNames.Add($name)
+$onlyFeatureMode = @($OnlyFeature).Count -gt 0
+if ($onlyFeatureMode -and ($Customize -or @($IncludeFeature).Count -gt 0 -or @($ExcludeFeature).Count -gt 0)) {
+    throw '-OnlyFeature cannot be combined with -Customize, -IncludeFeature, or -ExcludeFeature.'
 }
 
-$customFeatureRequested = $Customize -or @($IncludeFeature).Count -gt 0 -or @($ExcludeFeature).Count -gt 0
-$selectedFeatureIds = @(Resolve-FeatureSelection -Features $features -FeatureMap $featureMap -PolicyNames $policyNames -PresetName $Preset -IncludeNames $IncludeFeature -ExcludeNames $ExcludeFeature -UsePrompt:$Customize)
+$policyNames = New-Object System.Collections.Generic.List[string]
+
+if (-not $onlyFeatureMode) {
+    foreach ($name in Resolve-PresetPolicies -Name $Preset -Presets $presets) {
+        [void]$policyNames.Add($name)
+    }
+}
+
+$customFeatureRequested = $onlyFeatureMode -or $Customize -or @($IncludeFeature).Count -gt 0 -or @($ExcludeFeature).Count -gt 0
+$featurePresetName = if ($onlyFeatureMode) { '__OnlyFeature' } else { $Preset }
+$featureIncludeNames = if ($onlyFeatureMode) { $OnlyFeature } else { $IncludeFeature }
+$featureExcludeNames = if ($onlyFeatureMode) { @() } else { $ExcludeFeature }
+$selectedFeatureIds = @(Resolve-FeatureSelection -Features $features -FeatureMap $featureMap -PolicyNames $policyNames -PresetName $featurePresetName -IncludeNames $featureIncludeNames -ExcludeNames $featureExcludeNames -UsePrompt:$Customize)
 
 if ($LockShields) {
     foreach ($name in Resolve-PresetPolicies -Name 'ShieldBaseline' -Presets $presets) {

--- a/Invoke-BraveDebloat.ps1
+++ b/Invoke-BraveDebloat.ps1
@@ -1034,7 +1034,12 @@ if ($List) {
 
 $registryPath = Get-RegistryBasePath -ScopeName $Scope
 
-Write-Step "Preset: $Preset"
+if ($onlyFeatureMode) {
+    Write-Step 'Preset: (none - OnlyFeature mode)'
+}
+else {
+    Write-Step "Preset: $Preset"
+}
 Write-Step "Scope: $Scope ($registryPath)"
 if ($LockShields) {
     Write-Step 'Shield baseline: enabled. This enforces ad blocking, standard fingerprinting protection, HTTPS upgrade, and referrer capping.'

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Or make a scripted custom run:
 ```powershell
 .\Invoke-BraveDebloat.ps1 -Preset Extreme -ExcludeFeature News,LeoAI
 .\Invoke-BraveDebloat.ps1 -Preset Standard -IncludeFeature Translate
+.\Invoke-BraveDebloat.ps1 -OnlyFeature Rewards,Wallet,VPN
 ```
 
 PowerShell `-WhatIf` is supported as a no-write preview even when `-Apply` is present:
@@ -100,6 +101,8 @@ By default, the tool uses `Extreme` and does not lock Shield behavior. It also r
 ## Feature Toggles
 
 Use `-Customize` for an interactive yes/no prompt for each cleanup, or use `-IncludeFeature` and `-ExcludeFeature` for repeatable commands. Feature names are shown by `-ListFeatures`; examples include `Rewards`, `Wallet`, `VPN`, `LeoAI`, `News`, `Talk`, `Autofill`, `Translate`, and `GoogleSearchSidePanel`.
+
+Use `-OnlyFeature` when you want exactly the named cleanups without starting from a preset.
 
 When `-IncludeProfilePreferences` is combined with custom feature choices, profile preference patches are filtered to the selected features.
 

--- a/scripts/Test-Behavior.ps1
+++ b/scripts/Test-Behavior.ps1
@@ -54,6 +54,28 @@ try {
     $includeOutput = (& $scriptPath -Preset Standard -IncludeFeature Translate -List *>&1 | Out-String)
     Assert-TextContains -Text $includeOutput -Expected 'TranslateEnabled' -Context '-IncludeFeature output'
 
+    $onlyOutput = (& $scriptPath -OnlyFeature Rewards,Wallet -List *>&1 | Out-String)
+    Assert-TextContains -Text $onlyOutput -Expected 'BraveRewardsDisabled' -Context '-OnlyFeature output'
+    Assert-TextContains -Text $onlyOutput -Expected 'BraveWalletDisabled' -Context '-OnlyFeature output'
+    Assert-TextDoesNotContain -Text $onlyOutput -Unexpected 'BraveVPNDisabled' -Context '-OnlyFeature output'
+    Assert-TextDoesNotContain -Text $onlyOutput -Unexpected 'BraveAIChatEnabled' -Context '-OnlyFeature output'
+
+    $onlyPatchOutput = (& $scriptPath -OnlyFeature Rewards -List -IncludeProfilePreferences *>&1 | Out-String)
+    Assert-TextContains -Text $onlyPatchOutput -Expected 'brave.rewards.enabled' -Context '-OnlyFeature profile patch output'
+    Assert-TextDoesNotContain -Text $onlyPatchOutput -Unexpected 'brave.new_tab_page.show_branded_background_image' -Context '-OnlyFeature profile patch output'
+    Assert-TextDoesNotContain -Text $onlyPatchOutput -Unexpected 'brave.wallet.show_wallet_icon_on_toolbar' -Context '-OnlyFeature profile patch output'
+
+    $onlyConflictFailed = $false
+    try {
+        & $scriptPath -OnlyFeature Rewards -ExcludeFeature Wallet -List | Out-Null
+    }
+    catch {
+        $onlyConflictFailed = $_.Exception.Message -match 'OnlyFeature cannot be combined'
+    }
+    if (-not $onlyConflictFailed) {
+        throw '-OnlyFeature did not reject conflicting custom feature switches.'
+    }
+
     $filteredPatchOutput = (& $scriptPath -Preset Extreme -ExcludeFeature News,Rewards,Wallet -List -IncludeProfilePreferences *>&1 | Out-String)
     Assert-TextContains -Text $filteredPatchOutput -Expected 'brave.new_tab_page.show_branded_background_image' -Context 'filtered profile patch output'
     Assert-TextDoesNotContain -Text $filteredPatchOutput -Unexpected 'brave.today.should_show_toolbar_button' -Context 'filtered profile patch output'

--- a/scripts/Test-Behavior.ps1
+++ b/scripts/Test-Behavior.ps1
@@ -65,6 +65,11 @@ try {
     Assert-TextDoesNotContain -Text $onlyPatchOutput -Unexpected 'brave.new_tab_page.show_branded_background_image' -Context '-OnlyFeature profile patch output'
     Assert-TextDoesNotContain -Text $onlyPatchOutput -Unexpected 'brave.wallet.show_wallet_icon_on_toolbar' -Context '-OnlyFeature profile patch output'
 
+    $onlyDryRunOutput = (& $scriptPath -OnlyFeature Rewards *>&1 | Out-String)
+    Assert-TextContains -Text $onlyDryRunOutput -Expected 'Preset: (none - OnlyFeature mode)' -Context '-OnlyFeature dry-run output'
+    Assert-TextContains -Text $onlyDryRunOutput -Expected 'Custom features: Rewards' -Context '-OnlyFeature dry-run output'
+    Assert-TextDoesNotContain -Text $onlyDryRunOutput -Unexpected 'Preset: Extreme' -Context '-OnlyFeature dry-run output'
+
     $onlyConflictFailed = $false
     try {
         & $scriptPath -OnlyFeature Rewards -ExcludeFeature Wallet -List | Out-Null

--- a/scripts/Test-Behavior.ps1
+++ b/scripts/Test-Behavior.ps1
@@ -70,9 +70,16 @@ try {
     Assert-TextContains -Text $onlyDryRunOutput -Expected 'Custom features: Rewards' -Context '-OnlyFeature dry-run output'
     Assert-TextDoesNotContain -Text $onlyDryRunOutput -Unexpected 'Preset: Extreme' -Context '-OnlyFeature dry-run output'
 
-    $blankOnlyFeatureOutput = (& $scriptPath -OnlyFeature ' ' *>&1 | Out-String)
-    Assert-TextContains -Text $blankOnlyFeatureOutput -Expected 'Preset: Extreme' -Context 'blank -OnlyFeature output'
-    Assert-TextDoesNotContain -Text $blankOnlyFeatureOutput -Unexpected 'OnlyFeature mode' -Context 'blank -OnlyFeature output'
+    $blankOnlyFeatureFailed = $false
+    try {
+        & $scriptPath -OnlyFeature ' ' | Out-Null
+    }
+    catch {
+        $blankOnlyFeatureFailed = $_.Exception.Message -match 'Specified -OnlyFeature contains only blank entries'
+    }
+    if (-not $blankOnlyFeatureFailed) {
+        throw '-OnlyFeature did not reject blank-only input.'
+    }
 
     $onlyConflictCommands = @(
         { & $scriptPath -OnlyFeature Rewards -ExcludeFeature Wallet -List | Out-Null },

--- a/scripts/Test-Behavior.ps1
+++ b/scripts/Test-Behavior.ps1
@@ -70,15 +70,26 @@ try {
     Assert-TextContains -Text $onlyDryRunOutput -Expected 'Custom features: Rewards' -Context '-OnlyFeature dry-run output'
     Assert-TextDoesNotContain -Text $onlyDryRunOutput -Unexpected 'Preset: Extreme' -Context '-OnlyFeature dry-run output'
 
-    $onlyConflictFailed = $false
-    try {
-        & $scriptPath -OnlyFeature Rewards -ExcludeFeature Wallet -List | Out-Null
-    }
-    catch {
-        $onlyConflictFailed = $_.Exception.Message -match 'OnlyFeature cannot be combined'
-    }
-    if (-not $onlyConflictFailed) {
-        throw '-OnlyFeature did not reject conflicting custom feature switches.'
+    $blankOnlyFeatureOutput = (& $scriptPath -OnlyFeature ' ' *>&1 | Out-String)
+    Assert-TextContains -Text $blankOnlyFeatureOutput -Expected 'Preset: Extreme' -Context 'blank -OnlyFeature output'
+    Assert-TextDoesNotContain -Text $blankOnlyFeatureOutput -Unexpected 'OnlyFeature mode' -Context 'blank -OnlyFeature output'
+
+    $onlyConflictCommands = @(
+        { & $scriptPath -OnlyFeature Rewards -ExcludeFeature Wallet -List | Out-Null },
+        { & $scriptPath -OnlyFeature Rewards -IncludeFeature Wallet -List | Out-Null },
+        { & $scriptPath -OnlyFeature Rewards -Customize -List | Out-Null }
+    )
+    foreach ($command in $onlyConflictCommands) {
+        $onlyConflictFailed = $false
+        try {
+            & $command
+        }
+        catch {
+            $onlyConflictFailed = $_.Exception.Message -match 'OnlyFeature cannot be combined'
+        }
+        if (-not $onlyConflictFailed) {
+            throw '-OnlyFeature did not reject a conflicting custom feature switch.'
+        }
     }
 
     $filteredPatchOutput = (& $scriptPath -Preset Extreme -ExcludeFeature News,Rewards,Wallet -List -IncludeProfilePreferences *>&1 | Out-String)


### PR DESCRIPTION
## Summary

- Add `-OnlyFeature` for exact feature cleanup runs without starting from a preset.
- Reject ambiguous combinations with `-Customize`, `-IncludeFeature`, or `-ExcludeFeature`.
- Add behavior checks for exact policy selection, profile patch filtering, and conflicting switches.
- Document the new command in the README and changelog.

## Why

Users asked for more granular control. `-OnlyFeature` makes the common "just remove Rewards, Wallet, and VPN" flow shorter and less error-prone than starting from a preset and excluding everything else.

## Validation

- `./scripts/Test-PolicyManifest.ps1`
- `./scripts/Test-Behavior.ps1`
- `./Invoke-BraveDebloat.ps1 -Preset Extreme -LockShields`
- Windows PowerShell 5.1 compatibility checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added -OnlyFeature to run exactly the named feature cleanups (skips presets) and prevents combining with conflicting options; CLI shows "Preset: (none - OnlyFeature mode)".

* **Behavior**
  * Rejects whitespace-only entries; ignores blank names when evaluating include/exclude selections.

* **Documentation**
  * Updated README and changelog with -OnlyFeature usage and examples.

* **Tests**
  * Added tests for OnlyFeature output, selection handling, blank-entry rejection, and conflict errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->