### PR TITLE
Use approved PowerShell helper name

### DIFF
--- a/Invoke-BraveDebloat.ps1
+++ b/Invoke-BraveDebloat.ps1
@@ -196,7 +196,7 @@ function Assert-FeatureNames {
     }
 }
 
-function Normalize-FeatureNames {
+function Get-NormalizedFeatureName {
     param([string[]]$Names)
 
     $normalized = New-Object System.Collections.Generic.List[string]
@@ -981,9 +981,9 @@ $features = @($manifest.features)
 $featureMap = Get-FeatureMap -Features $features
 Assert-FeatureReferences -Features $features -PolicyDefinitions $policyDefinitions
 
-$normalizedOnlyFeature = @(Normalize-FeatureNames -Names $OnlyFeature)
-$normalizedIncludeFeature = @(Normalize-FeatureNames -Names $IncludeFeature)
-$normalizedExcludeFeature = @(Normalize-FeatureNames -Names $ExcludeFeature)
+$normalizedOnlyFeature = @(Get-NormalizedFeatureName -Names $OnlyFeature)
+$normalizedIncludeFeature = @(Get-NormalizedFeatureName -Names $IncludeFeature)
+$normalizedExcludeFeature = @(Get-NormalizedFeatureName -Names $ExcludeFeature)
 
 if ($PSBoundParameters.ContainsKey('OnlyFeature') -and $normalizedOnlyFeature.Count -eq 0) {
     throw 'Specified -OnlyFeature contains only blank entries; please provide a valid feature name.'


### PR DESCRIPTION
## Summary
- rename the feature normalization helper to use an approved PowerShell verb and singular noun
- keep the existing normalization behavior unchanged

## Validation
- .\scripts\Test-PolicyManifest.ps1
- .\scripts\Test-Behavior.ps1
- powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\Test-Behavior.ps1
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal update to feature-filter handling; normalization behavior (trimming, ignoring blanks, de-duplicating) and user-facing behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->