### PR TITLE
Configure Greptile reviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added Greptile review configuration for safety-focused pull request feedback.
 - Added `-OnlyFeature` for running exactly selected feature cleanups without starting from a preset.
 
 ## 0.2.0 - 2026-05-04

--- a/README.md
+++ b/README.md
@@ -162,3 +162,5 @@ Run the built-in manifest and syntax checks:
 ![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/osfv/BraveDebloater?utm_source=oss&utm_medium=github&utm_campaign=osfv%2FBraveDebloater&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
 
 Pull requests are configured for CodeRabbit review with repo-specific guidance in `.coderabbit.yaml`. Reviews should focus on PowerShell 5.1 compatibility, registry safety, backup/restore behavior, policy manifest integrity, and dry-run clarity.
+
+Greptile review guidance lives in `greptile.json` and mirrors the same safety-first focus for PowerShell compatibility, policy changes, registry writes, profile JSON writes, and feature-toggle behavior.

--- a/greptile.json
+++ b/greptile.json
@@ -1,6 +1,6 @@
 {
   "strictness": 2,
-  "commentTypes": ["logic", "syntax", "style", "info"],
+  "commentTypes": ["logic", "syntax", "style"],
   "triggerOnUpdates": true,
   "statusCommentsEnabled": true,
   "instructions": "Review BraveDebloater as a safety-first Windows PowerShell tool. Focus on Windows PowerShell 5.1 compatibility, ShouldProcess and WhatIf behavior, registry safety, backup and restore behavior, profile JSON writes, policy manifest integrity, feature-toggle behavior, and dry-run clarity. Avoid cosmetic comments unless they affect safety, compatibility, maintainability, or user-facing clarity.",

--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,37 @@
+{
+  "strictness": 2,
+  "commentTypes": ["logic", "syntax", "style", "info"],
+  "triggerOnUpdates": true,
+  "statusCommentsEnabled": true,
+  "instructions": "Review BraveDebloater as a safety-first Windows PowerShell tool. Focus on Windows PowerShell 5.1 compatibility, ShouldProcess and WhatIf behavior, registry safety, backup and restore behavior, profile JSON writes, policy manifest integrity, feature-toggle behavior, and dry-run clarity. Avoid cosmetic comments unless they affect safety, compatibility, maintainability, or user-facing clarity.",
+  "customContext": {
+    "files": [
+      {
+        "path": "CONTRIBUTING.md",
+        "description": "Project contribution and validation guidance."
+      },
+      {
+        "path": "SECURITY.md",
+        "description": "Safety and vulnerability reporting guidance."
+      },
+      {
+        "path": "config/policies.json",
+        "description": "Policy manifest used by the PowerShell script and manifest checks."
+      }
+    ],
+    "rules": [
+      {
+        "rule": "PowerShell changes must remain compatible with Windows PowerShell 5.1 and avoid syntax that requires PowerShell 7 or newer.",
+        "scope": ["**/*.ps1"]
+      },
+      {
+        "rule": "Changes that can write registry keys or profile Preferences JSON must preserve dry-run behavior, WhatIf behavior, backup creation, and restore safety.",
+        "scope": ["Invoke-BraveDebloat.ps1", "scripts/**/*.ps1"]
+      },
+      {
+        "rule": "Feature-toggle and policy-manifest changes must keep feature names, presets, policy references, and profile preference patches consistent with config/policies.json.",
+        "scope": ["Invoke-BraveDebloat.ps1", "config/**/*.json", "scripts/**/*.ps1"]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a root greptile.json with safety-focused review guidance for BraveDebloater
- point Greptile at project context files and PowerShell/registry/manifest review rules
- document the Greptile review config in the README and changelog

## Validation
- greptile.json parsed with ConvertFrom-Json
- .\scripts\Test-PolicyManifest.ps1
- .\scripts\Test-Behavior.ps1
- powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\Test-Behavior.ps1
- git diff --check