### PR TITLE
Add Doctor diagnostic mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added `-Doctor` for a read-only Brave policy, feature, backup, profile, and safety diagnostic report.
 - Added Greptile review configuration for safety-focused pull request feedback.
 - Added `-OnlyFeature` for running exactly selected feature cleanups without starting from a preset.
 

--- a/Invoke-BraveDebloat.ps1
+++ b/Invoke-BraveDebloat.ps1
@@ -9,6 +9,8 @@ param(
 
     [switch]$Apply,
 
+    [switch]$Doctor,
+
     [switch]$LockShields,
 
     [switch]$Customize,
@@ -318,6 +320,16 @@ function Test-IsAdministrator {
     return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 }
 
+function Get-RegistryPolicyPath {
+    param([string]$ScopeName)
+
+    if ($ScopeName -eq 'LocalMachine') {
+        return 'Registry::HKEY_LOCAL_MACHINE\Software\Policies\BraveSoftware\Brave'
+    }
+
+    return 'Registry::HKEY_CURRENT_USER\Software\Policies\BraveSoftware\Brave'
+}
+
 function Get-RegistryBasePath {
     param([string]$ScopeName)
 
@@ -325,10 +337,9 @@ function Get-RegistryBasePath {
         if (-not (Test-IsAdministrator)) {
             throw 'LocalMachine scope requires an elevated PowerShell session. Use -Scope CurrentUser or run as administrator.'
         }
-        return 'Registry::HKEY_LOCAL_MACHINE\Software\Policies\BraveSoftware\Brave'
     }
 
-    return 'Registry::HKEY_CURRENT_USER\Software\Policies\BraveSoftware\Brave'
+    return (Get-RegistryPolicyPath -ScopeName $ScopeName)
 }
 
 function Get-FullFileSystemPath {
@@ -517,6 +528,33 @@ function Assert-PolicySafety {
     }
 }
 
+function Get-PolicySafetyFinding {
+    param(
+        [string[]]$PolicyNames,
+        [Parameter(Mandatory = $true)]$Manifest
+    )
+
+    $findings = New-Object System.Collections.Generic.List[string]
+    $blockedNames = @($Manifest.safety.blockedPolicyNames)
+    $blockedPatterns = @($Manifest.safety.blockedNamePatterns)
+
+    foreach ($policyName in $PolicyNames) {
+        if ($blockedNames -contains $policyName) {
+            [void]$findings.Add("Protected policy '$policyName' is present.")
+            continue
+        }
+
+        foreach ($pattern in $blockedPatterns) {
+            if ($policyName -match $pattern) {
+                [void]$findings.Add("Policy '$policyName' matches protected pattern '$pattern'.")
+                break
+            }
+        }
+    }
+
+    return $findings.ToArray()
+}
+
 function Get-RegistrySnapshot {
     param(
         [string]$BasePath,
@@ -556,6 +594,138 @@ function Get-RegistrySnapshot {
     }
 
     return $snapshot.ToArray()
+}
+
+function Get-RegistryPolicyReport {
+    param([string]$ScopeName)
+
+    $path = Get-RegistryPolicyPath -ScopeName $ScopeName
+    $entries = New-Object System.Collections.Generic.List[object]
+    $keyExists = $false
+    $canRead = $true
+    $errorMessage = ''
+
+    try {
+        $keyExists = Test-Path -LiteralPath $path
+        if ($keyExists) {
+            $key = Get-Item -LiteralPath $path
+            foreach ($name in $key.GetValueNames()) {
+                if ([string]::IsNullOrWhiteSpace($name)) {
+                    continue
+                }
+
+                [void]$entries.Add([pscustomobject]@{
+                        Name = [string]$name
+                        Value = $key.GetValue($name, $null)
+                        Kind = $key.GetValueKind($name).ToString()
+                    })
+            }
+        }
+    }
+    catch {
+        $canRead = $false
+        $errorMessage = $_.Exception.Message
+    }
+
+    return [pscustomobject]@{
+        Scope = $ScopeName
+        Path = $path
+        KeyExists = $keyExists
+        CanRead = $canRead
+        ErrorMessage = $errorMessage
+        Entries = $entries.ToArray()
+    }
+}
+
+function Get-PolicyEntryMap {
+    param([object[]]$Entries)
+
+    $map = @{}
+    foreach ($entry in @($Entries)) {
+        $map[[string]$entry.Name] = $entry
+    }
+    return $map
+}
+
+function Test-PolicyValueMatches {
+    param(
+        $ActualValue,
+        $ExpectedValue,
+        [string]$Type
+    )
+
+    try {
+        if ($Type -eq 'DWord') {
+            return ([int64]$ActualValue -eq [int64]$ExpectedValue)
+        }
+        if ($Type -eq 'String') {
+            return ([string]$ActualValue -eq [string]$ExpectedValue)
+        }
+    }
+    catch {
+        return $false
+    }
+
+    return $false
+}
+
+function Get-FeaturePolicyStatus {
+    param(
+        [Parameter(Mandatory = $true)]$Feature,
+        [hashtable]$PolicyEntries,
+        [hashtable]$PolicyDefinitions
+    )
+
+    $policies = @($Feature.policies)
+    if ($policies.Count -eq 0) {
+        return 'Profile-only'
+    }
+
+    $present = 0
+    $matching = 0
+    foreach ($policyName in $policies) {
+        if (-not $PolicyEntries.ContainsKey($policyName)) {
+            continue
+        }
+
+        $present++
+        $definition = $PolicyDefinitions[$policyName]
+        if (Test-PolicyValueMatches -ActualValue $PolicyEntries[$policyName].Value -ExpectedValue $definition.value -Type ([string]$definition.type)) {
+            $matching++
+        }
+    }
+
+    if ($present -eq 0) {
+        return 'Not applied'
+    }
+    if ($matching -eq $policies.Count) {
+        return 'Applied'
+    }
+    if ($matching -gt 0) {
+        return 'Partial'
+    }
+    return 'Different'
+}
+
+function Get-BackupSummary {
+    param([string]$Directory)
+
+    $fullDirectory = Get-FullFileSystemPath -Path $Directory
+    $files = @()
+    if (Test-Path -LiteralPath $fullDirectory) {
+        $files = @(Get-ChildItem -LiteralPath $fullDirectory -Filter 'BraveDebloater-*.json' | Where-Object { -not $_.PSIsContainer } | Sort-Object LastWriteTime -Descending)
+    }
+
+    $latest = ''
+    if ($files.Count -gt 0) {
+        $latest = $files[0].FullName
+    }
+
+    return [pscustomobject]@{
+        Directory = $fullDirectory
+        Count = $files.Count
+        Latest = $latest
+    }
 }
 
 function New-BackupPath {
@@ -955,6 +1125,136 @@ function Show-ProfilePreferencePatchList {
     $rows | Format-Table -AutoSize -Wrap
 }
 
+function Show-DoctorReport {
+    param(
+        [Parameter(Mandatory = $true)]$Manifest,
+        [object[]]$Features,
+        [hashtable]$PolicyDefinitions,
+        [string]$ProfileRoot,
+        [string]$BackupDirectory
+    )
+
+    Write-Step 'Doctor report (read-only). No registry, backup, or profile files will be changed.'
+
+    $currentUserReport = Get-RegistryPolicyReport -ScopeName 'CurrentUser'
+    $localMachineReport = Get-RegistryPolicyReport -ScopeName 'LocalMachine'
+    $reports = @($currentUserReport, $localMachineReport)
+
+    foreach ($report in $reports) {
+        if (-not $report.CanRead) {
+            Write-Step "$($report.Scope) policies: read failed ($($report.ErrorMessage))"
+            continue
+        }
+
+        if ($report.Entries.Count -gt 0) {
+            Write-Step "$($report.Scope) policies: found $($report.Entries.Count) value(s)."
+        }
+        elseif ($report.KeyExists) {
+            Write-Step "$($report.Scope) policies: key exists but has no values."
+        }
+        else {
+            Write-Step "$($report.Scope) policies: none detected."
+        }
+    }
+
+    if ($localMachineReport.CanRead -and $localMachineReport.Entries.Count -gt 0) {
+        Write-Step 'Machine-wide policies: detected. Brave may show managed settings for all users.'
+    }
+    else {
+        Write-Step 'Machine-wide policies: none detected.'
+    }
+
+    $allPolicyNames = @($reports | ForEach-Object { @($_.Entries) } | ForEach-Object { [string]$_.Name })
+    $safetyFindings = @(Get-PolicySafetyFinding -PolicyNames $allPolicyNames -Manifest $Manifest)
+    if ($safetyFindings.Count -eq 0) {
+        Write-Step 'Safety: no protected Brave policy names detected.'
+    }
+    else {
+        foreach ($finding in $safetyFindings) {
+            Write-Warning "Safety: $finding"
+        }
+    }
+
+    $braveProcesses = @(Get-Process -Name brave -ErrorAction SilentlyContinue)
+    if ($braveProcesses.Count -gt 0) {
+        Write-Step "Brave process: running ($($braveProcesses.Count) process(es)). Profile preference cleanup would be skipped."
+    }
+    else {
+        Write-Step 'Brave process: not running.'
+    }
+
+    $profileFiles = @(Get-BraveProfilePreferenceFiles -Root $ProfileRoot)
+    if (Test-Path -LiteralPath $ProfileRoot) {
+        Write-Step "Profile root: found ($($profileFiles.Count) Preferences file(s)) - $ProfileRoot"
+    }
+    else {
+        Write-Step "Profile root: missing - $ProfileRoot"
+    }
+
+    $backupSummary = Get-BackupSummary -Directory $BackupDirectory
+    Write-Step "Backups: $($backupSummary.Count) found in $($backupSummary.Directory)"
+    if (-not [string]::IsNullOrWhiteSpace($backupSummary.Latest)) {
+        Write-Step "Latest backup: $($backupSummary.Latest)"
+    }
+
+    $currentUserPolicies = Get-PolicyEntryMap -Entries $currentUserReport.Entries
+    $localMachinePolicies = Get-PolicyEntryMap -Entries $localMachineReport.Entries
+
+    Write-Step 'Policy scopes:'
+    $scopeRows = foreach ($report in $reports) {
+        $status = 'Missing'
+        if (-not $report.CanRead) {
+            $status = 'Read failed'
+        }
+        elseif ($report.Entries.Count -gt 0) {
+            $status = 'Found'
+        }
+        elseif ($report.KeyExists) {
+            $status = 'Empty'
+        }
+
+        [pscustomobject]@{
+            Scope = $report.Scope
+            Status = $status
+            Values = $report.Entries.Count
+            Path = $report.Path
+        }
+    }
+    $scopeRows | Format-Table -AutoSize -Wrap
+
+    Write-Step 'Feature status:'
+    $featureRows = foreach ($feature in @($Features)) {
+        [pscustomobject]@{
+            Feature = [string]$feature.id
+            CurrentUser = Get-FeaturePolicyStatus -Feature $feature -PolicyEntries $currentUserPolicies -PolicyDefinitions $PolicyDefinitions
+            LocalMachine = Get-FeaturePolicyStatus -Feature $feature -PolicyEntries $localMachinePolicies -PolicyDefinitions $PolicyDefinitions
+            Label = [string]$feature.label
+        }
+    }
+    $featureRows | Format-Table -AutoSize -Wrap
+
+    $unknownRows = foreach ($report in $reports) {
+        foreach ($entry in @($report.Entries)) {
+            if (-not $PolicyDefinitions.ContainsKey([string]$entry.Name)) {
+                [pscustomobject]@{
+                    Scope = $report.Scope
+                    Policy = [string]$entry.Name
+                    Value = $entry.Value
+                    Kind = [string]$entry.Kind
+                }
+            }
+        }
+    }
+
+    if (@($unknownRows).Count -gt 0) {
+        Write-Step 'Unknown Brave policies: detected. These may have been set by Brave, another tool, or an organization.'
+        $unknownRows | Format-Table -AutoSize -Wrap
+    }
+    else {
+        Write-Step 'Unknown Brave policies: none detected.'
+    }
+}
+
 $manifest = Get-Manifest
 $applyChanges = $Apply -and -not $WhatIfPreference
 $isWhatIf = $Apply -and $WhatIfPreference
@@ -980,6 +1280,11 @@ $policyDefinitions = Get-ManifestMap -Object $manifest.policies
 $features = @($manifest.features)
 $featureMap = Get-FeatureMap -Features $features
 Assert-FeatureReferences -Features $features -PolicyDefinitions $policyDefinitions
+
+if ($Doctor) {
+    Show-DoctorReport -Manifest $manifest -Features $features -PolicyDefinitions $policyDefinitions -ProfileRoot $ProfileRoot -BackupDirectory $BackupDirectory
+    return
+}
 
 $normalizedOnlyFeature = @(Get-NormalizedFeatureName -Names $OnlyFeature)
 $normalizedIncludeFeature = @(Get-NormalizedFeatureName -Names $IncludeFeature)

--- a/Invoke-BraveDebloat.ps1
+++ b/Invoke-BraveDebloat.ps1
@@ -625,6 +625,7 @@ function Get-RegistryPolicyReport {
     catch {
         $canRead = $false
         $errorMessage = $_.Exception.Message
+        $entries.Clear()
     }
 
     return [pscustomobject]@{
@@ -655,7 +656,7 @@ function Test-PolicyValueMatches {
     )
 
     try {
-        if ($Type -eq 'DWord') {
+        if ($Type -eq 'DWord' -or $Type -eq 'QWord') {
             return ([int64]$ActualValue -eq [int64]$ExpectedValue)
         }
         if ($Type -eq 'String') {
@@ -1286,6 +1287,9 @@ $featureMap = Get-FeatureMap -Features $features
 Assert-FeatureReferences -Features $features -PolicyDefinitions $policyDefinitions
 
 if ($Doctor) {
+    if ($Apply) {
+        Write-Warning '-Doctor is read-only. -Apply is ignored in Doctor mode.'
+    }
     Show-DoctorReport -Manifest $manifest -Features $features -PolicyDefinitions $policyDefinitions -ProfileRoot $ProfileRoot -BackupDirectory $BackupDirectory
     return
 }

--- a/Invoke-BraveDebloat.ps1
+++ b/Invoke-BraveDebloat.ps1
@@ -1230,8 +1230,8 @@ function Show-DoctorReport {
     $featureRows = foreach ($feature in @($Features)) {
         [pscustomobject]@{
             Feature = [string]$feature.id
-            CurrentUser = Get-FeaturePolicyStatus -Feature $feature -PolicyEntries $currentUserPolicies -PolicyDefinitions $PolicyDefinitions
-            LocalMachine = Get-FeaturePolicyStatus -Feature $feature -PolicyEntries $localMachinePolicies -PolicyDefinitions $PolicyDefinitions
+            CurrentUser = if (-not $currentUserReport.CanRead) { 'Read failed' } else { Get-FeaturePolicyStatus -Feature $feature -PolicyEntries $currentUserPolicies -PolicyDefinitions $PolicyDefinitions }
+            LocalMachine = if (-not $localMachineReport.CanRead) { 'Read failed' } else { Get-FeaturePolicyStatus -Feature $feature -PolicyEntries $localMachinePolicies -PolicyDefinitions $PolicyDefinitions }
             Label = [string]$feature.label
         }
     }

--- a/Invoke-BraveDebloat.ps1
+++ b/Invoke-BraveDebloat.ps1
@@ -1157,7 +1157,10 @@ function Show-DoctorReport {
         }
     }
 
-    if ($localMachineReport.CanRead -and $localMachineReport.Entries.Count -gt 0) {
+    if (-not $localMachineReport.CanRead) {
+        Write-Step 'Machine-wide policies: unknown because LocalMachine policies could not be read.'
+    }
+    elseif ($localMachineReport.Entries.Count -gt 0) {
         Write-Step 'Machine-wide policies: detected. Brave may show managed settings for all users.'
     }
     else {
@@ -1233,22 +1236,23 @@ function Show-DoctorReport {
     }
     $featureRows | Format-Table -AutoSize -Wrap
 
-    $unknownRows = foreach ($report in $reports) {
+    $unknownRows = New-Object System.Collections.Generic.List[object]
+    foreach ($report in $reports) {
         foreach ($entry in @($report.Entries)) {
             if (-not $PolicyDefinitions.ContainsKey([string]$entry.Name)) {
-                [pscustomobject]@{
-                    Scope = $report.Scope
-                    Policy = [string]$entry.Name
-                    Value = $entry.Value
-                    Kind = [string]$entry.Kind
-                }
+                [void]$unknownRows.Add([pscustomobject]@{
+                        Scope = $report.Scope
+                        Policy = [string]$entry.Name
+                        Value = $entry.Value
+                        Kind = [string]$entry.Kind
+                    })
             }
         }
     }
 
-    if (@($unknownRows).Count -gt 0) {
+    if ($unknownRows.Count -gt 0) {
         Write-Step 'Unknown Brave policies: detected. These may have been set by Brave, another tool, or an organization.'
-        $unknownRows | Format-Table -AutoSize -Wrap
+        $unknownRows.ToArray() | Format-Table -AutoSize -Wrap
     }
     else {
         Write-Step 'Unknown Brave policies: none detected.'

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ List the available feature toggles:
 .\Invoke-BraveDebloat.ps1 -ListFeatures
 ```
 
+Run a read-only health check of Brave policies, backups, profile files, and detected feature status:
+
+```powershell
+.\Invoke-BraveDebloat.ps1 -Doctor
+```
+
 Apply it for the current Windows user:
 
 ```powershell
@@ -105,6 +111,12 @@ Use `-Customize` for an interactive yes/no prompt for each cleanup, or use `-Inc
 Use `-OnlyFeature` when you want exactly the named cleanups without starting from a preset.
 
 When `-IncludeProfilePreferences` is combined with custom feature choices, profile preference patches are filtered to the selected features.
+
+## Doctor Mode
+
+Use `-Doctor` to inspect the current Brave policy state without writing anything. It reports CurrentUser and LocalMachine policy keys, detected feature status, unknown Brave policies, protected policy names, Brave process state, profile preference files, and available backups.
+
+This is useful after testing other debloat tools because machine-wide policies can make Brave settings appear managed for every Windows user.
 
 ## Profile Preferences
 

--- a/scripts/Test-Behavior.ps1
+++ b/scripts/Test-Behavior.ps1
@@ -60,6 +60,16 @@ try {
     Assert-TextDoesNotContain -Text $doctorOutput -Unexpected '[dry-run]' -Context '-Doctor output'
     Assert-TextDoesNotContain -Text $doctorOutput -Unexpected 'Would set' -Context '-Doctor output'
 
+    $doctorApplyBackupDirectory = Join-Path $tempRoot 'DoctorApplyBackups'
+    $doctorApplyOutput = (& $scriptPath -Doctor -Apply -ProfileRoot $missingProfileRoot -BackupDirectory $doctorApplyBackupDirectory *>&1 | Out-String)
+    Assert-TextContains -Text $doctorApplyOutput -Expected '-Doctor is read-only. -Apply is ignored in Doctor mode.' -Context '-Doctor -Apply output'
+    Assert-TextContains -Text $doctorApplyOutput -Expected 'Doctor report (read-only)' -Context '-Doctor -Apply output'
+    Assert-TextDoesNotContain -Text $doctorApplyOutput -Unexpected 'Backup written' -Context '-Doctor -Apply output'
+    Assert-TextDoesNotContain -Text $doctorApplyOutput -Unexpected 'Would set' -Context '-Doctor -Apply output'
+    if (Test-Path -LiteralPath $doctorApplyBackupDirectory) {
+        throw '-Doctor -Apply created a backup directory.'
+    }
+
     $excludeOutput = (& $scriptPath -Preset Extreme -ExcludeFeature News,LeoAI -List *>&1 | Out-String)
     Assert-TextContains -Text $excludeOutput -Expected 'BraveRewardsDisabled' -Context '-ExcludeFeature output'
     Assert-TextDoesNotContain -Text $excludeOutput -Unexpected 'BraveNewsDisabled' -Context '-ExcludeFeature output'

--- a/scripts/Test-Behavior.ps1
+++ b/scripts/Test-Behavior.ps1
@@ -46,6 +46,20 @@ try {
     Assert-TextContains -Text $featureOutput -Expected 'LeoAI' -Context '-ListFeatures output'
     Assert-TextContains -Text $featureOutput -Expected 'Brave Rewards' -Context '-ListFeatures output'
 
+    $doctorBackupDirectory = Join-Path $tempRoot 'DoctorBackups'
+    New-Item -ItemType Directory -Path $doctorBackupDirectory -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $doctorBackupDirectory 'BraveDebloater-20260101-010101-001.json') -Value '{}' -Encoding UTF8
+
+    $doctorOutput = (& $scriptPath -Doctor -ProfileRoot $missingProfileRoot -BackupDirectory $doctorBackupDirectory *>&1 | Out-String)
+    Assert-TextContains -Text $doctorOutput -Expected 'Doctor report (read-only)' -Context '-Doctor output'
+    Assert-TextContains -Text $doctorOutput -Expected 'CurrentUser policies' -Context '-Doctor output'
+    Assert-TextContains -Text $doctorOutput -Expected 'LocalMachine policies' -Context '-Doctor output'
+    Assert-TextContains -Text $doctorOutput -Expected 'Feature status' -Context '-Doctor output'
+    Assert-TextContains -Text $doctorOutput -Expected 'Backups: 1 found' -Context '-Doctor output'
+    Assert-TextContains -Text $doctorOutput -Expected 'Profile root: missing' -Context '-Doctor output'
+    Assert-TextDoesNotContain -Text $doctorOutput -Unexpected '[dry-run]' -Context '-Doctor output'
+    Assert-TextDoesNotContain -Text $doctorOutput -Unexpected 'Would set' -Context '-Doctor output'
+
     $excludeOutput = (& $scriptPath -Preset Extreme -ExcludeFeature News,LeoAI -List *>&1 | Out-String)
     Assert-TextContains -Text $excludeOutput -Expected 'BraveRewardsDisabled' -Context '-ExcludeFeature output'
     Assert-TextDoesNotContain -Text $excludeOutput -Unexpected 'BraveNewsDisabled' -Context '-ExcludeFeature output'


### PR DESCRIPTION
## Summary
- add a read-only -Doctor mode for Brave policy, feature, profile, backup, and safety diagnostics
- report CurrentUser and LocalMachine policy scope status without requiring elevation for read-only checks
- document the new mode and cover it in behavior tests

## Validation
- .\scripts\Test-PolicyManifest.ps1
- .\scripts\Test-Behavior.ps1
- powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\Test-Behavior.ps1
- git diff --check (only Windows CRLF normalization warnings)