### PR TITLE
Skip invalid profile Preferences files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Skip unreadable or invalid profile `Preferences` files with a warning instead of failing the whole profile preference cleanup run.
 - Added `-Doctor` for a read-only Brave policy, feature, backup, profile, and safety diagnostic report.
 - Added Greptile review configuration for safety-focused pull request feedback.
 - Added `-OnlyFeature` for running exactly selected feature cleanups without starting from a preset.

--- a/Invoke-BraveDebloat.ps1
+++ b/Invoke-BraveDebloat.ps1
@@ -1018,7 +1018,24 @@ function Invoke-ProfilePreferenceCleanup {
             Write-DryRun "Would inspect profile file $file."
         }
 
-        $json = Get-Content -LiteralPath $file -Raw | ConvertFrom-Json
+        $json = $null
+        try {
+            $raw = Get-Content -LiteralPath $file -Raw
+            if ([string]::IsNullOrWhiteSpace($raw)) {
+                throw 'The file is empty.'
+            }
+            $json = $raw | ConvertFrom-Json
+        }
+        catch {
+            Write-Warning "Skipping invalid profile Preferences file: $file ($($_.Exception.Message))"
+            continue
+        }
+
+        if ($json -isnot [System.Management.Automation.PSCustomObject]) {
+            Write-Warning "Skipping invalid profile Preferences file: $file (top-level value is not a JSON object)."
+            continue
+        }
+
         $changed = $false
 
         foreach ($patch in $patches) {

--- a/scripts/Test-Behavior.ps1
+++ b/scripts/Test-Behavior.ps1
@@ -175,6 +175,33 @@ try {
     $restoreOutput = (& $scriptPath -UndoFromBackup $validBackup *>&1 | Out-String)
     Assert-TextContains -Text $restoreOutput -Expected 'Would remove BraveRewardsDisabled' -Context 'restore dry-run output'
 
+    $mixedProfileRoot = Join-Path $tempRoot 'MixedProfileRoot'
+    $invalidProfileDirectory = Join-Path $mixedProfileRoot 'Default'
+    $emptyProfileDirectory = Join-Path $mixedProfileRoot 'Profile 1'
+    $validProfileDirectory = Join-Path $mixedProfileRoot 'Profile 2'
+    New-Item -ItemType Directory -Path $invalidProfileDirectory -Force | Out-Null
+    New-Item -ItemType Directory -Path $emptyProfileDirectory -Force | Out-Null
+    New-Item -ItemType Directory -Path $validProfileDirectory -Force | Out-Null
+    $invalidPreferences = Join-Path $invalidProfileDirectory 'Preferences'
+    $emptyPreferences = Join-Path $emptyProfileDirectory 'Preferences'
+    $validPreferences = Join-Path $validProfileDirectory 'Preferences'
+    Set-Content -LiteralPath $invalidPreferences -Value '{ this is not valid json' -Encoding UTF8 -NoNewline
+    Set-Content -LiteralPath $emptyPreferences -Value '' -Encoding UTF8 -NoNewline
+    Set-Content -LiteralPath $validPreferences -Value '{}' -Encoding UTF8 -NoNewline
+
+    $invalidJsonOutput = (& $scriptPath -Preset Core -IncludeProfilePreferences -ProfileRoot $mixedProfileRoot *>&1 | Out-String)
+    $skipCount = ([regex]::Matches($invalidJsonOutput, 'Skipping invalid profile Preferences file')).Count
+    if ($skipCount -ne 2) {
+        throw "Expected 2 skipped profile Preferences files, found $skipCount."
+    }
+    Assert-TextContains -Text $invalidJsonOutput -Expected 'Would create brave.new_tab_page.show_branded_background_image' -Context 'valid Preferences dry-run output'
+    Assert-TextContains -Text $invalidJsonOutput -Expected 'Dry-run complete.' -Context 'invalid Preferences dry-run output'
+
+    $invalidJsonContentBefore = Get-Content -LiteralPath $invalidPreferences -Raw
+    if ($invalidJsonContentBefore -ne '{ this is not valid json') {
+        throw 'Dry-run modified an invalid profile Preferences file.'
+    }
+
     Write-Host 'Behavior checks passed.'
 }
 finally {


### PR DESCRIPTION
## Summary
- skip profile `Preferences` files that are empty, unparsable, or not a top-level JSON object during profile preference cleanup, with a warning naming the file, instead of failing the whole run
- keep processing the remaining profiles and never write to the invalid file
- cover the invalid, empty, and valid profile mix in behavior tests and assert dry-run leaves the invalid file untouched

## Validation
- .\scripts\Test-PolicyManifest.ps1
- .\scripts\Test-Behavior.ps1
- reproduced the crash on main with a corrupted Default/Preferences next to a valid profile, then confirmed the fix warns, skips, and completes the dry-run

Fixes #12
