### PR TITLE
Add cross-platform Brave policy support

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: "en-US"
 early_access: false
-tone_instructions: "Be concise and direct. Prioritize correctness, safety, Windows PowerShell 5.1 compatibility, and user-impacting behavior over style nits."
+tone_instructions: "Be concise and direct. Focus review comments on correctness, safety, cross-platform PowerShell behavior, and user-impacting behavior. Do not leave style-only comments."
 
 reviews:
-  profile: "chill"
-  request_changes_workflow: false
+  profile: "assertive"
+  request_changes_workflow: true
   high_level_summary: true
   review_status: true
   review_details: true
@@ -16,13 +16,25 @@ reviews:
     auto_incremental_review: true
   path_instructions:
     - path: "Invoke-BraveDebloat.ps1"
-      instructions: "Focus on Windows PowerShell 5.1 compatibility, ShouldProcess and WhatIf behavior, registry safety, backup and restore behavior, profile JSON writes, and dry-run clarity. Avoid cosmetic style comments unless they affect safety or readability."
+      instructions: "Block changes that break PowerShell 5.1 compatibility, ShouldProcess, WhatIf, dry-run default behavior, or the requirement that -Apply is needed before writes. Check that user-facing output says what happened, whether anything changed, and what to do next."
+    - path: "src/*.ps1"
+      instructions: "Block changes that weaken policy targeting, backup validation, restore validation, profile Preferences safety, platform detection, or mobile MDM export behavior. Windows must use registry policy keys. macOS must use defaults or plist payloads. Linux must use managed JSON policy files. Android and iOS must export MDM payloads only."
     - path: "config/policies.json"
-      instructions: "Verify policy names, preset inheritance, feature mappings, and safety blocks. Pay special attention to anything that could disable Brave Shields, weaken Safe Browsing, disable updates, or make profile cleanup too broad."
+      instructions: "Block policies that disable Brave updates, disable Brave Shields, add Shield allowlists, weaken Safe Browsing, remove extensions, or expand profile cleanup beyond selected Brave Preferences paths. Verify policy names, preset inheritance, feature mappings, platformSupport metadata, and safety blocks."
     - path: "scripts/*.ps1"
-      instructions: "Check that tests cover manifest integrity, feature toggles, restore validation, dry-run behavior, and Windows PowerShell 5.1 compatibility."
+      instructions: "Require tests to cover changed behavior. Keep coverage for manifest integrity, feature toggles, restore validation, dry-run behavior, profile preference handling, mobile export, and Windows PowerShell 5.1 compatibility."
     - path: ".github/workflows/*.yml"
-      instructions: "Check that CI still validates both PowerShell 7 and Windows PowerShell 5.1 paths."
+      instructions: "Block CI changes that remove PowerShell 7 validation on Windows, macOS, and Linux, remove Windows PowerShell 5.1 validation, remove official Brave template validation, loosen read-only permissions, or remove job timeouts."
+    - path: "docs/**"
+      instructions: "Require source-backed claims for policy support. Keep user guidance short, concrete, and action-oriented. Do not add broad trust-me claims about Brave policy behavior."
+    - path: "AGENTS.md"
+      instructions: "Keep repository instructions aligned with this CodeRabbit configuration. Preserve the rules for PowerShell as the runtime, native platform policy writes, mobile MDM export-only behavior, policy safety blocks, dry-run defaults, and restore validation."
+    - path: "CLAUDE.md"
+      instructions: "This file must remain a symlink to AGENTS.md."
+    - path: "GEMINI.md"
+      instructions: "This file must remain a symlink to AGENTS.md."
+    - path: ".github/copilot-instructions.md"
+      instructions: "This file must remain a symlink to ../AGENTS.md."
 
 chat:
   auto_reply: true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,20 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
-    runs-on: windows-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -24,6 +35,28 @@ jobs:
       - name: Dry-run extreme preset
         shell: pwsh
         run: ./Invoke-BraveDebloat.ps1 -Preset Extreme -LockShields
+
+  source-validation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Download Brave policy templates
+        shell: pwsh
+        run: Invoke-WebRequest -Uri 'https://brave-browser-downloads.s3.brave.com/latest/policy_templates.zip' -OutFile policy_templates.zip
+
+      - name: Validate manifest against official Brave templates
+        shell: pwsh
+        run: ./scripts/Test-LatestPolicyTemplates.ps1 -TemplateZipPath ./policy_templates.zip
+
+  windows-powershell:
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
 
       - name: Validate Windows PowerShell 5.1 compatibility
         shell: powershell

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ backups/
 *.tmp
 .DS_Store
 Thumbs.db
+
+# Codebase MCP
+.codebase-memory/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# AGENTS.md
+
+BraveDebloater is a PowerShell 5.1-compatible Brave Browser policy tool.
+
+PowerShell is the cross-platform runtime. Keep platform-specific writes native:
+
+- Windows: Brave registry policy keys.
+- macOS: `defaults` or managed plist policy payloads.
+- Linux: managed JSON policy files.
+- Android/iOS: export MDM payloads only; do not add local device writes.
+
+## Code Discovery
+
+Use codebase-memory-mcp before text search for code structure:
+
+1. `search_graph`
+2. `trace_path`
+3. `get_code_snippet`
+4. `query_graph`
+5. `search_code`
+
+Use `rg` for docs, configs, literal strings, and when the graph is not enough.
+
+## Safety Rules
+
+Do not add policies that disable Brave updates, disable Brave Shields, add Shield allowlists, weaken Safe Browsing, or remove extensions.
+
+Keep dry-run as the default. `-Apply` must be required before writes.
+
+Keep backup and restore validation strict. Restores must stay limited to Brave policy targets and selected Brave profile `Preferences` files.
+
+Profile preference cleanup must not run while Brave is open.
+
+## Implementation Notes
+
+Keep `Invoke-BraveDebloat.ps1` as the thin entrypoint. Put shared behavior in `src/*.ps1`.
+
+Use existing helpers before adding new ones.
+
+Keep user-facing messages short, concrete, and action-oriented. Say what happened, whether anything changed, and what to do next.
+
+When adding or changing policies, update:
+
+- `config/policies.json`
+- `docs/debloatable-validation.md`
+- `scripts/Test-PolicyManifest.ps1` or `scripts/Test-LatestPolicyTemplates.ps1` if validation rules change
+
+## Checks
+
+Run the local checks before handing off:
+
+```powershell
+pwsh -NoProfile -File scripts/Test-PolicyManifest.ps1
+pwsh -NoProfile -File scripts/Test-Behavior.ps1
+```
+
+When a Brave policy template zip is available, also run:
+
+```powershell
+pwsh -NoProfile -File scripts/Test-LatestPolicyTemplates.ps1 -TemplateZipPath /tmp/brave-policy-templates.zip
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,14 @@ Thanks for helping make BraveDebloater safer and cleaner.
 - Keep restore behavior working whenever a new write path is added.
 - Treat `-List` and `-WhatIf` as read-only paths.
 
+## AI Agent And LLM Contributions
+
+If an AI agent, coding assistant, or autonomous workflow changes this repository, it must follow `AGENTS.md`.
+
+Agent-made changes must stay coherent across code, docs, tests, and configuration. If a change touches policy behavior, platform behavior, restore behavior, user-facing output, or CI, update every affected file in the same pull request.
+
+Do not submit agent output that only patches the visible symptom. Trace the shared path, fix the common cause, and run the checks below.
+
 ## Checks
 
 Before opening a pull request, run:

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Invoke-BraveDebloat.ps1
+++ b/Invoke-BraveDebloat.ps1
@@ -1,3 +1,4 @@
+#!/usr/bin/env pwsh
 #requires -Version 5.1
 [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
 param(

--- a/Invoke-BraveDebloat.ps1
+++ b/Invoke-BraveDebloat.ps1
@@ -179,8 +179,11 @@ if ($policyTarget.Kind -eq 'MobileMDM' -and $applyChanges) {
     throw "$platformName policies require MDM deployment. This script can list or export the selected policies, but it cannot apply them on-device."
 }
 
+# Enforce the iOS/iPadOS MDM allowlist for every run (dry-run, apply, and export) so the
+# preview never implies on-device support for policies Brave's mobile MDM cannot accept.
+Assert-MobilePolicySupport -PlatformName $platformName -PolicyNames $policyNames.ToArray() -Manifest $manifest
+
 if (-not [string]::IsNullOrWhiteSpace($ExportPolicyPath)) {
-    Assert-MobilePolicySupport -PlatformName $platformName -PolicyNames $policyNames.ToArray() -Manifest $manifest
     $payload = Get-PolicyPayload -PolicyNames $policyNames.ToArray() -PolicyDefinitions $policyDefinitions
     Export-PolicyPayload -Target $policyTarget -Payload $payload -Path $ExportPolicyPath
     Write-Step "Exported $($policyNames.Count) policy value(s) for $platformName to $ExportPolicyPath. Apply that file with your device or policy manager."

--- a/Invoke-BraveDebloat.ps1
+++ b/Invoke-BraveDebloat.ps1
@@ -4,6 +4,9 @@ param(
     [ValidateSet('Standard', 'High', 'Extreme', 'Core', 'Privacy', 'Aggressive')]
     [string]$Preset = 'Extreme',
 
+    [ValidateSet('Auto', 'Windows', 'macOS', 'Linux', 'Android', 'iOS')]
+    [string]$Platform = 'Auto',
+
     [ValidateSet('CurrentUser', 'LocalMachine')]
     [string]$Scope = 'CurrentUser',
 
@@ -23,7 +26,11 @@ param(
 
     [switch]$IncludeProfilePreferences,
 
-    [string]$ProfileRoot = (Join-Path $env:LOCALAPPDATA 'BraveSoftware\Brave-Browser\User Data'),
+    [string]$ProfileRoot,
+
+    [string]$PolicyPath,
+
+    [string]$ExportPolicyPath,
 
     [string]$BackupDirectory,
 
@@ -50,1255 +57,31 @@ if ([string]::IsNullOrWhiteSpace($BackupDirectory)) {
     $BackupDirectory = Join-Path $ProjectRoot 'backups'
 }
 
-function Write-Step {
-    param([string]$Message)
-    Write-Host "[BraveDebloater] $Message"
-}
-
-function Write-DryRun {
-    param([string]$Message)
-    Write-Host "[dry-run] $Message"
-}
-
-function Get-Manifest {
-    $manifestPath = Join-Path $ProjectRoot 'config\policies.json'
-    if (-not (Test-Path -LiteralPath $manifestPath)) {
-        throw "Cannot find policy manifest at $manifestPath."
-    }
-
-    return Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
-}
-
-function Get-ManifestMap {
-    param([Parameter(Mandatory = $true)]$Object)
-
-    $map = @{}
-    foreach ($property in $Object.PSObject.Properties) {
-        $map[$property.Name] = $property.Value
-    }
-    return $map
-}
-
-function Resolve-PresetPolicies {
-    param(
-        [Parameter(Mandatory = $true)][string]$Name,
-        [Parameter(Mandatory = $true)][hashtable]$Presets,
-        [hashtable]$Seen = @{}
-    )
-
-    if (-not $Presets.ContainsKey($Name)) {
-        throw "Unknown preset '$Name'."
-    }
-    if ($Seen.ContainsKey($Name)) {
-        throw "Preset cycle detected at '$Name'."
-    }
-
-    $Seen[$Name] = $true
-    $resolved = New-Object System.Collections.Generic.List[string]
-
-    foreach ($entry in @($Presets[$Name])) {
-        if ($entry -isnot [string]) {
-            throw "Preset '$Name' contains a non-string entry."
-        }
-
-        if ($entry.StartsWith('@')) {
-            $childName = $entry.Substring(1)
-            foreach ($childPolicy in Resolve-PresetPolicies -Name $childName -Presets $Presets -Seen ($Seen.Clone())) {
-                if (-not $resolved.Contains($childPolicy)) {
-                    [void]$resolved.Add($childPolicy)
-                }
-            }
-        }
-        elseif (-not $resolved.Contains($entry)) {
-            [void]$resolved.Add($entry)
-        }
-    }
-
-    return $resolved.ToArray()
-}
-
-function Get-FeatureMap {
-    param([object[]]$Features)
-
-    $map = @{}
-    foreach ($feature in @($Features)) {
-        $id = [string]$feature.id
-        if ([string]::IsNullOrWhiteSpace($id)) {
-            throw 'Feature entry is missing an id.'
-        }
-        if ($map.ContainsKey($id)) {
-            throw "Duplicate feature id '$id'."
-        }
-        $map[$id] = $feature
-    }
-    return $map
-}
-
-function Get-FeaturePolicies {
-    param([Parameter(Mandatory = $true)]$Feature)
-
-    return @($Feature.policies) | ForEach-Object { [string]$_ }
-}
-
-function Add-StringIfMissing {
-    param(
-        [Parameter(Mandatory = $true)]$List,
-        [Parameter(Mandatory = $true)][string]$Value
-    )
-
-    if (-not $List.Contains($Value)) {
-        [void]$List.Add($Value)
-    }
-}
-
-function Remove-StringFromList {
-    param(
-        [Parameter(Mandatory = $true)]$List,
-        [Parameter(Mandatory = $true)][string]$Value
-    )
-
-    while ($List.Remove($Value)) {
-    }
-}
-
-function Test-FeatureSelectedByPolicy {
-    param(
-        [Parameter(Mandatory = $true)]$Feature,
-        [Parameter(Mandatory = $true)]$PolicyNames,
-        [Parameter(Mandatory = $true)][string]$PresetName
-    )
-
-    $policies = @(Get-FeaturePolicies -Feature $Feature)
-    if ($policies.Count -eq 0) {
-        return (@($Feature.defaultPresets) -contains $PresetName)
-    }
-
-    foreach ($policyName in $policies) {
-        if (-not $PolicyNames.Contains($policyName)) {
-            return $false
-        }
-    }
-    return $true
-}
-
-function Assert-FeatureNames {
-    param(
-        [string[]]$Names,
-        [Parameter(Mandatory = $true)][hashtable]$FeatureMap
-    )
-
-    foreach ($name in @($Names)) {
-        if ([string]::IsNullOrWhiteSpace([string]$name)) {
-            continue
-        }
-        if (-not $FeatureMap.ContainsKey($name)) {
-            $available = ($FeatureMap.Keys | Sort-Object) -join ', '
-            throw "Unknown feature '$name'. Available features: $available"
-        }
-    }
-}
-
-function Get-NormalizedFeatureName {
-    param([string[]]$Names)
-
-    $normalized = New-Object System.Collections.Generic.List[string]
-    foreach ($name in @($Names)) {
-        $trimmed = ([string]$name).Trim()
-        if ([string]::IsNullOrWhiteSpace($trimmed)) {
-            continue
-        }
-        Add-StringIfMissing -List $normalized -Value $trimmed
-    }
-    return $normalized.ToArray()
-}
-
-function Assert-FeatureReferences {
-    param(
-        [object[]]$Features,
-        [Parameter(Mandatory = $true)][hashtable]$PolicyDefinitions
-    )
-
-    foreach ($feature in @($Features)) {
-        foreach ($policyName in Get-FeaturePolicies -Feature $feature) {
-            if (-not $PolicyDefinitions.ContainsKey($policyName)) {
-                throw "Feature '$($feature.id)' references undefined policy '$policyName'."
-            }
-        }
-    }
-}
-
-function Set-FeatureSelection {
-    param(
-        [Parameter(Mandatory = $true)]$Feature,
-        [Parameter(Mandatory = $true)]$PolicyNames,
-        [Parameter(Mandatory = $true)]$SelectedFeatureIds,
-        [Parameter(Mandatory = $true)][bool]$Selected
-    )
-
-    $featureId = [string]$Feature.id
-    if ($Selected) {
-        Add-StringIfMissing -List $SelectedFeatureIds -Value $featureId
-        foreach ($policyName in Get-FeaturePolicies -Feature $Feature) {
-            Add-StringIfMissing -List $PolicyNames -Value $policyName
-        }
-        return
-    }
-
-    Remove-StringFromList -List $SelectedFeatureIds -Value $featureId
-    foreach ($policyName in Get-FeaturePolicies -Feature $Feature) {
-        Remove-StringFromList -List $PolicyNames -Value $policyName
-    }
-}
-
-function Read-FeatureChoice {
-    param(
-        [Parameter(Mandatory = $true)]$Feature,
-        [Parameter(Mandatory = $true)][bool]$Default
-    )
-
-    $defaultLabel = if ($Default) { 'Y/n' } else { 'y/N' }
-    $prompt = "Apply $($Feature.label) cleanup? [$defaultLabel]"
-    while ($true) {
-        $answer = (Read-Host $prompt).Trim()
-        if ([string]::IsNullOrWhiteSpace($answer)) {
-            return $Default
-        }
-        switch ($answer.ToLowerInvariant()) {
-            { $_ -in @('y', 'yes') } { return $true }
-            { $_ -in @('n', 'no') } { return $false }
-            default { Write-Host 'Please answer y or n.' }
-        }
-    }
-}
-
-function Resolve-FeatureSelection {
-    param(
-        [object[]]$Features,
-        [Parameter(Mandatory = $true)][hashtable]$FeatureMap,
-        [Parameter(Mandatory = $true)]$PolicyNames,
-        [Parameter(Mandatory = $true)][string]$PresetName,
-        [string[]]$IncludeNames,
-        [string[]]$ExcludeNames,
-        [switch]$UsePrompt
-    )
-
-    $selectedFeatureIds = New-Object System.Collections.Generic.List[string]
-    foreach ($feature in @($Features)) {
-        if (Test-FeatureSelectedByPolicy -Feature $feature -PolicyNames $PolicyNames -PresetName $PresetName) {
-            Add-StringIfMissing -List $selectedFeatureIds -Value ([string]$feature.id)
-        }
-    }
-
-    if ($UsePrompt) {
-        foreach ($feature in @($Features)) {
-            $default = $selectedFeatureIds.Contains([string]$feature.id)
-            $selected = Read-FeatureChoice -Feature $feature -Default $default
-            Set-FeatureSelection -Feature $feature -PolicyNames $PolicyNames -SelectedFeatureIds $selectedFeatureIds -Selected:$selected
-        }
-    }
-
-    foreach ($featureName in @($IncludeNames)) {
-        if ([string]::IsNullOrWhiteSpace([string]$featureName)) {
-            continue
-        }
-        Set-FeatureSelection -Feature $FeatureMap[$featureName] -PolicyNames $PolicyNames -SelectedFeatureIds $selectedFeatureIds -Selected:$true
-    }
-
-    foreach ($featureName in @($ExcludeNames)) {
-        if ([string]::IsNullOrWhiteSpace([string]$featureName)) {
-            continue
-        }
-        Set-FeatureSelection -Feature $FeatureMap[$featureName] -PolicyNames $PolicyNames -SelectedFeatureIds $selectedFeatureIds -Selected:$false
-    }
-
-    return $selectedFeatureIds.ToArray()
-}
-
-function Test-IsAdministrator {
-    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
-    $principal = New-Object Security.Principal.WindowsPrincipal($identity)
-    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-}
-
-function Get-RegistryPolicyPath {
-    param([string]$ScopeName)
-
-    if ($ScopeName -eq 'LocalMachine') {
-        return 'Registry::HKEY_LOCAL_MACHINE\Software\Policies\BraveSoftware\Brave'
-    }
-
-    return 'Registry::HKEY_CURRENT_USER\Software\Policies\BraveSoftware\Brave'
-}
-
-function Get-RegistryBasePath {
-    param([string]$ScopeName)
-
-    if ($ScopeName -eq 'LocalMachine') {
-        if (-not (Test-IsAdministrator)) {
-            throw 'LocalMachine scope requires an elevated PowerShell session. Use -Scope CurrentUser or run as administrator.'
-        }
-    }
-
-    return (Get-RegistryPolicyPath -ScopeName $ScopeName)
-}
-
-function Get-FullFileSystemPath {
-    param([Parameter(Mandatory = $true)][string]$Path)
-
-    if ([string]::IsNullOrWhiteSpace($Path)) {
-        throw 'Expected a non-empty filesystem path.'
-    }
-
-    try {
-        return [System.IO.Path]::GetFullPath($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path))
-    }
-    catch {
-        return [System.IO.Path]::GetFullPath($Path)
-    }
-}
-
-function Test-PathIsUnderDirectory {
-    param(
-        [Parameter(Mandatory = $true)][string]$Path,
-        [Parameter(Mandatory = $true)][string]$Directory
-    )
-
-    $fullPath = Get-FullFileSystemPath -Path $Path
-    $fullDirectory = Get-FullFileSystemPath -Path $Directory
-    $separator = [System.IO.Path]::DirectorySeparatorChar
-
-    if (-not $fullDirectory.EndsWith([string]$separator, [StringComparison]::OrdinalIgnoreCase)) {
-        $fullDirectory = "$fullDirectory$separator"
-    }
-
-    return $fullPath.StartsWith($fullDirectory, [StringComparison]::OrdinalIgnoreCase)
-}
-
-function Get-RequiredPropertyValue {
-    param(
-        [Parameter(Mandatory = $true)]$Object,
-        [Parameter(Mandatory = $true)][string]$Name,
-        [Parameter(Mandatory = $true)][string]$Context
-    )
-
-    $property = $Object.PSObject.Properties[$Name]
-    if ($null -eq $property) {
-        throw "$Context is missing required property '$Name'."
-    }
-
-    return $property.Value
-}
-
-function Assert-BackupRegistryPath {
-    param(
-        [Parameter(Mandatory = $true)][string]$RegistryPath,
-        [switch]$DoApply
-    )
-
-    $allowedPaths = @(
-        'Registry::HKEY_CURRENT_USER\Software\Policies\BraveSoftware\Brave',
-        'Registry::HKEY_LOCAL_MACHINE\Software\Policies\BraveSoftware\Brave'
-    )
-
-    if ($allowedPaths -notcontains $RegistryPath) {
-        throw "Backup contains untrusted registry path '$RegistryPath'."
-    }
-
-    if ($DoApply -and $RegistryPath -ieq 'Registry::HKEY_LOCAL_MACHINE\Software\Policies\BraveSoftware\Brave' -and -not (Test-IsAdministrator)) {
-        throw 'Restoring a LocalMachine backup requires an elevated PowerShell session.'
-    }
-}
-
-function Assert-BackupPolicyList {
-    param(
-        [Parameter(Mandatory = $true)]$Backup,
-        [Parameter(Mandatory = $true)][hashtable]$PolicyDefinitions
-    )
-
-    if ($null -eq $Backup.PSObject.Properties['policies']) {
-        throw "Backup is missing required property 'policies'."
-    }
-
-    foreach ($policy in @($Backup.policies)) {
-        $name = [string](Get-RequiredPropertyValue -Object $policy -Name 'name' -Context 'Backup policy')
-        $existed = Get-RequiredPropertyValue -Object $policy -Name 'existed' -Context "Backup policy '$name'"
-
-        if (-not ($existed -is [bool])) {
-            throw "Backup policy '$name' has a non-boolean 'existed' value."
-        }
-        if (-not $PolicyDefinitions.ContainsKey($name)) {
-            throw "Backup policy '$name' is not managed by this manifest."
-        }
-
-        if ($existed) {
-            $kind = [string](Get-RequiredPropertyValue -Object $policy -Name 'kind' -Context "Backup policy '$name'")
-            if (@('DWord', 'String') -notcontains $kind) {
-                throw "Backup policy '$name' has unsupported registry kind '$kind'."
-            }
-            if ($kind -ne [string]$PolicyDefinitions[$name].type) {
-                throw "Backup policy '$name' registry kind '$kind' does not match the manifest type '$($PolicyDefinitions[$name].type)'."
-            }
-
-            $value = Get-RequiredPropertyValue -Object $policy -Name 'value' -Context "Backup policy '$name'"
-            if ($kind -eq 'DWord' -and $value -isnot [int] -and $value -isnot [long]) {
-                throw "Backup policy '$name' is DWord but has non-integer value '$value'."
-            }
-            if ($kind -eq 'String' -and $value -isnot [string]) {
-                throw "Backup policy '$name' is String but has non-string value '$value'."
-            }
-        }
-    }
-}
-
-function Assert-BackupProfileFile {
-    param(
-        [Parameter(Mandatory = $true)]$ProfileFile,
-        [Parameter(Mandatory = $true)][string]$BackupPath,
-        [Parameter(Mandatory = $true)][string]$ProfileRoot
-    )
-
-    $source = [string](Get-RequiredPropertyValue -Object $ProfileFile -Name 'backupPath' -Context 'Backup profile file')
-    $target = [string](Get-RequiredPropertyValue -Object $ProfileFile -Name 'originalPath' -Context 'Backup profile file')
-    $backupDirectory = Split-Path -Parent (Get-FullFileSystemPath -Path $BackupPath)
-    $profileBackupDirectory = Join-Path $backupDirectory 'profile-files'
-
-    # Profile restores should only read files created beside the selected backup.
-    if (-not (Test-PathIsUnderDirectory -Path $source -Directory $profileBackupDirectory)) {
-        throw "Backup profile source is outside the expected backup folder: $source"
-    }
-
-    # Profile restores should only write Brave Preferences files under the selected profile root.
-    if (-not (Test-PathIsUnderDirectory -Path $target -Directory $ProfileRoot)) {
-        throw "Backup profile target is outside the selected profile root: $target"
-    }
-    if ((Split-Path -Leaf $target) -ne 'Preferences') {
-        throw "Backup profile target is not a Brave Preferences file: $target"
-    }
-}
-
-function Assert-BackupObject {
-    param(
-        [Parameter(Mandatory = $true)]$Backup,
-        [Parameter(Mandatory = $true)]$Manifest,
-        [Parameter(Mandatory = $true)][string]$BackupPath,
-        [Parameter(Mandatory = $true)][string]$ProfileRoot,
-        [switch]$DoApply
-    )
-
-    $schemaVersion = Get-RequiredPropertyValue -Object $Backup -Name 'schemaVersion' -Context 'Backup'
-    if ($schemaVersion -ne 1) {
-        throw "Unsupported backup schema version '$schemaVersion'."
-    }
-
-    $registryPath = [string](Get-RequiredPropertyValue -Object $Backup -Name 'registryPath' -Context 'Backup')
-    Assert-BackupRegistryPath -RegistryPath $registryPath -DoApply:$DoApply
-
-    $policyDefinitions = Get-ManifestMap -Object $Manifest.policies
-    Assert-BackupPolicyList -Backup $Backup -PolicyDefinitions $policyDefinitions
-
-    $profileFiles = @()
-    if ($null -ne $Backup.PSObject.Properties['profileFiles']) {
-        $profileFiles = @($Backup.profileFiles)
-    }
-
-    foreach ($profileFile in $profileFiles) {
-        Assert-BackupProfileFile -ProfileFile $profileFile -BackupPath $BackupPath -ProfileRoot $ProfileRoot
-    }
-}
-
-function Assert-PolicySafety {
-    param(
-        [string[]]$PolicyNames,
-        [Parameter(Mandatory = $true)]$Manifest
-    )
-
-    $blockedNames = @($Manifest.safety.blockedPolicyNames)
-    $blockedPatterns = @($Manifest.safety.blockedNamePatterns)
-
-    foreach ($policyName in $PolicyNames) {
-        if ($blockedNames -contains $policyName) {
-            throw "Refusing to apply protected policy '$policyName'."
-        }
-
-        foreach ($pattern in $blockedPatterns) {
-            if ($policyName -match $pattern) {
-                throw "Refusing to apply '$policyName' because it matches protected pattern '$pattern'."
-            }
-        }
-    }
-}
-
-function Get-PolicySafetyFinding {
-    param(
-        [string[]]$PolicyNames,
-        [Parameter(Mandatory = $true)]$Manifest
-    )
-
-    $findings = New-Object System.Collections.Generic.List[string]
-    $blockedNames = @($Manifest.safety.blockedPolicyNames)
-    $blockedPatterns = @($Manifest.safety.blockedNamePatterns)
-
-    foreach ($policyName in $PolicyNames) {
-        if ($blockedNames -contains $policyName) {
-            [void]$findings.Add("Protected policy '$policyName' is present.")
-            continue
-        }
-
-        foreach ($pattern in $blockedPatterns) {
-            if ($policyName -match $pattern) {
-                [void]$findings.Add("Policy '$policyName' matches protected pattern '$pattern'.")
-                break
-            }
-        }
-    }
-
-    return $findings.ToArray()
-}
-
-function Get-RegistrySnapshot {
-    param(
-        [string]$BasePath,
-        [string[]]$PolicyNames
-    )
-
-    $snapshot = New-Object System.Collections.Generic.List[object]
-    $keyExists = Test-Path -LiteralPath $BasePath
-    $key = $null
-    if ($keyExists) {
-        $key = Get-Item -LiteralPath $BasePath
-    }
-
-    foreach ($policyName in $PolicyNames) {
-        $entry = [ordered]@{
-            name = $policyName
-            existed = $false
-            value = $null
-            kind = $null
-        }
-
-        if ($keyExists) {
-            try {
-                $value = $key.GetValue($policyName, $null)
-                if ($null -ne $value) {
-                    $entry.existed = $true
-                    $entry.value = $value
-                    $entry.kind = $key.GetValueKind($policyName).ToString()
-                }
-            }
-            catch {
-                $entry.existed = $false
-            }
-        }
-
-        [void]$snapshot.Add([pscustomobject]$entry)
-    }
-
-    return $snapshot.ToArray()
-}
-
-function Get-RegistryPolicyReport {
-    param([string]$ScopeName)
-
-    $path = Get-RegistryPolicyPath -ScopeName $ScopeName
-    $entries = New-Object System.Collections.Generic.List[object]
-    $keyExists = $false
-    $canRead = $true
-    $errorMessage = ''
-
-    try {
-        $keyExists = Test-Path -LiteralPath $path
-        if ($keyExists) {
-            $key = Get-Item -LiteralPath $path
-            foreach ($name in $key.GetValueNames()) {
-                if ([string]::IsNullOrWhiteSpace($name)) {
-                    continue
-                }
-
-                [void]$entries.Add([pscustomobject]@{
-                        Name = [string]$name
-                        Value = $key.GetValue($name, $null)
-                        Kind = $key.GetValueKind($name).ToString()
-                    })
-            }
-        }
-    }
-    catch {
-        $canRead = $false
-        $errorMessage = $_.Exception.Message
-        $entries.Clear()
-    }
-
-    return [pscustomobject]@{
-        Scope = $ScopeName
-        Path = $path
-        KeyExists = $keyExists
-        CanRead = $canRead
-        ErrorMessage = $errorMessage
-        Entries = $entries.ToArray()
-    }
-}
-
-function Get-PolicyEntryMap {
-    param([object[]]$Entries)
-
-    $map = @{}
-    foreach ($entry in @($Entries)) {
-        $map[[string]$entry.Name] = $entry
-    }
-    return $map
-}
-
-function Test-PolicyValueMatches {
-    param(
-        $ActualValue,
-        $ExpectedValue,
-        [string]$Type
-    )
-
-    try {
-        if ($Type -eq 'DWord' -or $Type -eq 'QWord') {
-            return ([int64]$ActualValue -eq [int64]$ExpectedValue)
-        }
-        if ($Type -eq 'String') {
-            return ([string]$ActualValue -eq [string]$ExpectedValue)
-        }
-    }
-    catch {
-        return $false
-    }
-
-    return $false
-}
-
-function Get-FeaturePolicyStatus {
-    param(
-        [Parameter(Mandatory = $true)]$Feature,
-        [hashtable]$PolicyEntries,
-        [hashtable]$PolicyDefinitions
-    )
-
-    $policies = @($Feature.policies)
-    if ($policies.Count -eq 0) {
-        return 'Profile-only'
-    }
-
-    $present = 0
-    $matching = 0
-    foreach ($policyName in $policies) {
-        if (-not $PolicyEntries.ContainsKey($policyName)) {
-            continue
-        }
-
-        $present++
-        $definition = $PolicyDefinitions[$policyName]
-        if (Test-PolicyValueMatches -ActualValue $PolicyEntries[$policyName].Value -ExpectedValue $definition.value -Type ([string]$definition.type)) {
-            $matching++
-        }
-    }
-
-    if ($present -eq 0) {
-        return 'Not applied'
-    }
-    if ($matching -eq $policies.Count) {
-        return 'Applied'
-    }
-    if ($matching -gt 0) {
-        return 'Partial'
-    }
-    return 'Different'
-}
-
-function Get-BackupSummary {
-    param([string]$Directory)
-
-    $fullDirectory = Get-FullFileSystemPath -Path $Directory
-    $files = @()
-    if (Test-Path -LiteralPath $fullDirectory) {
-        $files = @(Get-ChildItem -LiteralPath $fullDirectory -Filter 'BraveDebloater-*.json' | Where-Object { -not $_.PSIsContainer } | Sort-Object LastWriteTime -Descending)
-    }
-
-    $latest = ''
-    if ($files.Count -gt 0) {
-        $latest = $files[0].FullName
-    }
-
-    return [pscustomobject]@{
-        Directory = $fullDirectory
-        Count = $files.Count
-        Latest = $latest
-    }
-}
-
-function New-BackupPath {
-    param([string]$Directory)
-
-    $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss-fff'
-    $path = Join-Path $Directory "BraveDebloater-$timestamp.json"
-    if (-not (Test-Path -LiteralPath $path)) {
-        return $path
-    }
-
-    $suffix = [guid]::NewGuid().ToString('N').Substring(0, 8)
-    return (Join-Path $Directory "BraveDebloater-$timestamp-$suffix.json")
-}
-
-function Set-JsonFileContent {
-    param(
-        [Parameter(Mandatory = $true)][string]$Path,
-        [Parameter(Mandatory = $true)]$Object,
-        [int]$Depth = 20
-    )
-
-    $directory = Split-Path -Parent $Path
-    if (-not (Test-Path -LiteralPath $directory)) {
-        New-Item -ItemType Directory -Path $directory -Force | Out-Null
-    }
-
-    $tempPath = Join-Path $directory ('.{0}.tmp' -f [guid]::NewGuid().ToString('N'))
-    try {
-        $Object | ConvertTo-Json -Depth $Depth | Set-Content -LiteralPath $tempPath -Encoding UTF8
-        Move-Item -LiteralPath $tempPath -Destination $Path -Force
-    }
-    finally {
-        if (Test-Path -LiteralPath $tempPath) {
-            Remove-Item -LiteralPath $tempPath -Force
-        }
-    }
-}
-
-function New-Backup {
-    param(
-        [string]$Directory,
-        [string]$ScopeName,
-        [string]$RegistryPath,
-        [string[]]$PolicyNames,
-        [string]$ProfileRoot,
-        [Parameter(Mandatory = $true)]$Manifest
-    )
-
-    $Directory = Get-FullFileSystemPath -Path $Directory
-    if (-not (Test-Path -LiteralPath $Directory)) {
-        New-Item -ItemType Directory -Path $Directory -Force | Out-Null
-    }
-
-    $path = New-BackupPath -Directory $Directory
-    $backup = [ordered]@{
-        schemaVersion = 1
-        createdAt = (Get-Date).ToString('o')
-        manifestSchemaVersion = $Manifest.schemaVersion
-        policyTemplateVersion = $Manifest.policyTemplateVersion
-        scope = $ScopeName
-        registryPath = $RegistryPath
-        profileRoot = $ProfileRoot
-        policies = @(Get-RegistrySnapshot -BasePath $RegistryPath -PolicyNames $PolicyNames)
-        profileFiles = @()
-    }
-
-    Set-JsonFileContent -Path $path -Object $backup -Depth 20
-    return $path
-}
-
-function Update-BackupProfileFiles {
-    param(
-        [string]$BackupPath,
-        [object[]]$ProfileFiles
-    )
-
-    if (-not $BackupPath -or -not (Test-Path -LiteralPath $BackupPath)) {
-        return
-    }
-
-    $backup = Get-Content -LiteralPath $BackupPath -Raw | ConvertFrom-Json
-    $backup.profileFiles = @($ProfileFiles)
-    Set-JsonFileContent -Path $BackupPath -Object $backup -Depth 20
-}
-
-function Set-BravePolicy {
-    param(
-        [string]$BasePath,
-        [string]$Name,
-        [Parameter(Mandatory = $true)]$Definition
-    )
-
-    if (-not (Test-Path -LiteralPath $BasePath)) {
-        New-Item -Path $BasePath -Force | Out-Null
-    }
-
-    $propertyType = switch ($Definition.type) {
-        'DWord' { 'DWord' }
-        'String' { 'String' }
-        default { throw "Unsupported registry type '$($Definition.type)' for policy '$Name'." }
-    }
-
-    $value = $Definition.value
-    if ($Definition.type -eq 'DWord') {
-        $value = [int]$value
-    }
-
-    New-ItemProperty -LiteralPath $BasePath -Name $Name -Value $value -PropertyType $propertyType -Force | Out-Null
-}
-
-function Restore-RegistryBackup {
-    param(
-        [string]$BackupPath,
-        [Parameter(Mandatory = $true)]$Manifest,
-        [Parameter(Mandatory = $true)][string]$ProfileRoot,
-        [switch]$DoApply
-    )
-
-    if (-not (Test-Path -LiteralPath $BackupPath)) {
-        throw "Backup file not found: $BackupPath"
-    }
-
-    $backup = Get-Content -LiteralPath $BackupPath -Raw | ConvertFrom-Json
-    Assert-BackupObject -Backup $backup -Manifest $Manifest -BackupPath $BackupPath -ProfileRoot $ProfileRoot -DoApply:$DoApply
-    $registryPath = [string]$backup.registryPath
-
-    foreach ($policy in @($backup.policies)) {
-        $name = [string]$policy.name
-        $existed = [bool]$policy.existed
-        if (-not $DoApply) {
-            if ($existed) {
-                Write-DryRun "Would restore $name to '$($policy.value)' ($($policy.kind))."
-            }
-            else {
-                Write-DryRun "Would remove $name because it did not exist before."
-            }
-            continue
-        }
-
-        if ($existed) {
-            if (-not (Test-Path -LiteralPath $registryPath)) {
-                New-Item -Path $registryPath -Force | Out-Null
-            }
-
-            $kind = [string]$policy.kind
-            $value = $policy.value
-            if ($kind -eq 'DWord') {
-                $value = [int]$value
-            }
-
-            New-ItemProperty -LiteralPath $registryPath -Name $name -Value $value -PropertyType $kind -Force | Out-Null
-            Write-Step "Restored $name."
-        }
-        elseif (Test-Path -LiteralPath $registryPath) {
-            Remove-ItemProperty -LiteralPath $registryPath -Name $name -ErrorAction SilentlyContinue
-            Write-Step "Removed $name."
-        }
-    }
-
-    foreach ($profileFile in @($backup.profileFiles)) {
-        $source = [string]$profileFile.backupPath
-        $target = [string]$profileFile.originalPath
-
-        if (-not $DoApply) {
-            Write-DryRun "Would restore profile file $target."
-            continue
-        }
-
-        if (Test-Path -LiteralPath $source) {
-            $targetDirectory = Split-Path -Parent $target
-            if (-not (Test-Path -LiteralPath $targetDirectory)) {
-                New-Item -ItemType Directory -Path $targetDirectory -Force | Out-Null
-            }
-            Copy-Item -LiteralPath $source -Destination $target -Force
-            Write-Step "Restored profile file $target."
-        }
-        else {
-            Write-Warning "Profile backup missing: $source"
-        }
-    }
-}
-
-function Get-JsonPathResult {
-    param(
-        [Parameter(Mandatory = $true)]$Object,
-        [Parameter(Mandatory = $true)][string]$Path
-    )
-
-    $current = $Object
-    foreach ($part in ($Path -split '\.')) {
-        if ($null -eq $current -or $null -eq $current.PSObject.Properties[$part]) {
-            return [pscustomobject]@{ exists = $false; value = $null }
-        }
-        $current = $current.PSObject.Properties[$part].Value
-    }
-
-    return [pscustomobject]@{ exists = $true; value = $current }
-}
-
-function Set-JsonPathValue {
-    param(
-        [Parameter(Mandatory = $true)]$Object,
-        [Parameter(Mandatory = $true)][string]$Path,
-        [Parameter(Mandatory = $true)]$Value,
-        [bool]$CreateMissing = $false
-    )
-
-    $parts = $Path -split '\.'
-    $current = $Object
-
-    for ($i = 0; $i -lt ($parts.Count - 1); $i++) {
-        $part = $parts[$i]
-        if ($null -eq $current.PSObject.Properties[$part]) {
-            if (-not $CreateMissing) {
-                return $false
-            }
-            $child = [pscustomobject]@{}
-            $current | Add-Member -NotePropertyName $part -NotePropertyValue $child
-        }
-        $current = $current.PSObject.Properties[$part].Value
-    }
-
-    $leaf = $parts[-1]
-    if ($null -eq $current.PSObject.Properties[$leaf]) {
-        if (-not $CreateMissing) {
-            return $false
-        }
-        $current | Add-Member -NotePropertyName $leaf -NotePropertyValue $Value
-    }
-    else {
-        $current.PSObject.Properties[$leaf].Value = $Value
-    }
-
-    return $true
-}
-
-function Get-BraveProfilePreferenceFiles {
-    param([string]$Root)
-
-    $files = New-Object System.Collections.Generic.List[string]
-    if (-not (Test-Path -LiteralPath $Root)) {
-        return $files.ToArray()
-    }
-
-    Get-ChildItem -LiteralPath $Root -Directory -ErrorAction SilentlyContinue |
-        ForEach-Object {
-            $preferencesPath = Join-Path $_.FullName 'Preferences'
-            if (Test-Path -LiteralPath $preferencesPath) {
-                [void]$files.Add($preferencesPath)
-            }
-        }
-
-    return $files.ToArray()
-}
-
-function Invoke-ProfilePreferenceCleanup {
-    param(
-        [string]$Root,
-        [Parameter(Mandatory = $true)]$Manifest,
-        [string]$BackupPath,
-        [string[]]$SelectedFeatureIds = @(),
-        [switch]$UseFeatureFilter,
-        [switch]$DoApply
-    )
-
-    $files = @(Get-BraveProfilePreferenceFiles -Root $Root)
-    if ($files.Count -eq 0) {
-        Write-Warning "No Brave profile files found under $Root."
-        return
-    }
-
-    if ($DoApply -and (Get-Process -Name brave -ErrorAction SilentlyContinue)) {
-        Write-Warning 'Brave is running, so profile preference cleanup was skipped. Close Brave and rerun with -IncludeProfilePreferences to apply those cosmetic patches.'
-        return
-    }
-
-    $profileBackups = New-Object System.Collections.Generic.List[object]
-    $patches = @($Manifest.profilePreferencePatches)
-    if ($UseFeatureFilter) {
-        $patches = @($patches | Where-Object {
-                $featureId = [string]$_.feature
-                [string]::IsNullOrWhiteSpace($featureId) -or ($SelectedFeatureIds -contains $featureId)
-            })
-    }
-
-    foreach ($file in $files) {
-        if (-not $DoApply) {
-            Write-DryRun "Would inspect profile file $file."
-        }
-
-        $json = $null
-        try {
-            $raw = Get-Content -LiteralPath $file -Raw
-            if ([string]::IsNullOrWhiteSpace($raw)) {
-                throw 'The file is empty.'
-            }
-            $json = $raw | ConvertFrom-Json
-        }
-        catch {
-            Write-Warning "Skipping invalid profile Preferences file: $file ($($_.Exception.Message))"
-            continue
-        }
-
-        if ($json -isnot [System.Management.Automation.PSCustomObject]) {
-            Write-Warning "Skipping invalid profile Preferences file: $file (top-level value is not a JSON object)."
-            continue
-        }
-
-        $changed = $false
-
-        foreach ($patch in $patches) {
-            $path = [string]$patch.path
-            if ($path -match '(?i)shield') {
-                throw "Refusing profile preference patch that mentions Shields: $path"
-            }
-
-            $current = Get-JsonPathResult -Object $json -Path $path
-            $createMissing = [bool]$patch.createMissing
-
-            if (-not $current.exists -and -not $createMissing) {
-                continue
-            }
-
-            if (-not $DoApply) {
-                if ($current.exists) {
-                    Write-DryRun "Would set $path in $file from '$($current.value)' to '$($patch.value)'."
-                }
-                else {
-                    Write-DryRun "Would create $path in $file with '$($patch.value)'."
-                }
-                continue
-            }
-
-            if (Set-JsonPathValue -Object $json -Path $path -Value $patch.value -CreateMissing:$createMissing) {
-                $changed = $true
-            }
-        }
-
-        if ($DoApply -and $changed) {
-            $profileBackupDirectory = Join-Path (Split-Path -Parent $BackupPath) 'profile-files'
-            if (-not (Test-Path -LiteralPath $profileBackupDirectory)) {
-                New-Item -ItemType Directory -Path $profileBackupDirectory -Force | Out-Null
-            }
-
-            $safeName = ($file -replace '[:\\\/ ]', '_')
-            $profileBackupPath = Join-Path $profileBackupDirectory "$safeName.bak"
-            Copy-Item -LiteralPath $file -Destination $profileBackupPath -Force
-            [void]$profileBackups.Add([pscustomobject]@{
-                originalPath = $file
-                backupPath = $profileBackupPath
-            })
-
-            Set-JsonFileContent -Path $file -Object $json -Depth 100
-            Write-Step "Updated profile preferences in $file."
-        }
-    }
-
-    if ($DoApply -and $profileBackups.Count -gt 0) {
-        Update-BackupProfileFiles -BackupPath $BackupPath -ProfileFiles $profileBackups.ToArray()
-    }
-}
-
-function Show-PolicyList {
-    param(
-        [string[]]$PolicyNames,
-        [hashtable]$PolicyDefinitions
-    )
-
-    $rows = foreach ($name in $PolicyNames) {
-        $definition = $PolicyDefinitions[$name]
-        [pscustomobject]@{
-            Policy = $name
-            Value = $definition.value
-            Category = $definition.category
-            Reason = $definition.reason
-        }
-    }
-
-    $rows | Format-Table -AutoSize -Wrap
-}
-
-function Show-FeatureList {
-    param(
-        [object[]]$Features,
-        [string[]]$SelectedFeatureIds
-    )
-
-    $rows = foreach ($feature in @($Features)) {
-        [pscustomobject]@{
-            Feature = [string]$feature.id
-            Selected = ($SelectedFeatureIds -contains [string]$feature.id)
-            Label = [string]$feature.label
-            Reason = [string]$feature.reason
-        }
-    }
-
-    $rows | Format-Table -AutoSize -Wrap
-}
-
-function Show-ProfilePreferencePatchList {
-    param([object[]]$Patches)
-
-    $rows = foreach ($patch in @($Patches)) {
-        [pscustomobject]@{
-            Feature = [string]$patch.feature
-            PreferencePath = [string]$patch.path
-            Value = $patch.value
-            CreateMissing = [bool]$patch.createMissing
-            Reason = [string]$patch.reason
-        }
-    }
-
-    $rows | Format-Table -AutoSize -Wrap
-}
-
-function Show-DoctorReport {
-    param(
-        [Parameter(Mandatory = $true)]$Manifest,
-        [object[]]$Features,
-        [hashtable]$PolicyDefinitions,
-        [string]$ProfileRoot,
-        [string]$BackupDirectory
-    )
-
-    Write-Step 'Doctor report (read-only). No registry, backup, or profile files will be changed.'
-
-    $currentUserReport = Get-RegistryPolicyReport -ScopeName 'CurrentUser'
-    $localMachineReport = Get-RegistryPolicyReport -ScopeName 'LocalMachine'
-    $reports = @($currentUserReport, $localMachineReport)
-    $unreadableScopes = New-Object System.Collections.Generic.List[string]
-
-    foreach ($report in $reports) {
-        if (-not $report.CanRead) {
-            [void]$unreadableScopes.Add([string]$report.Scope)
-            Write-Step "$($report.Scope) policies: read failed ($($report.ErrorMessage))"
-            continue
-        }
-
-        if ($report.Entries.Count -gt 0) {
-            Write-Step "$($report.Scope) policies: found $($report.Entries.Count) value(s)."
-        }
-        elseif ($report.KeyExists) {
-            Write-Step "$($report.Scope) policies: key exists but has no values."
-        }
-        else {
-            Write-Step "$($report.Scope) policies: none detected."
-        }
-    }
-
-    if (-not $localMachineReport.CanRead) {
-        Write-Step 'Machine-wide policies: unknown because LocalMachine policies could not be read.'
-    }
-    elseif ($localMachineReport.Entries.Count -gt 0) {
-        Write-Step 'Machine-wide policies: detected. Brave may show managed settings for all users.'
-    }
-    else {
-        Write-Step 'Machine-wide policies: none detected.'
-    }
-
-    $allPolicyNames = @($reports | ForEach-Object { @($_.Entries) } | ForEach-Object { [string]$_.Name })
-    $safetyFindings = @(Get-PolicySafetyFinding -PolicyNames $allPolicyNames -Manifest $Manifest)
-    if ($unreadableScopes.Count -gt 0) {
-        Write-Warning "Safety: check incomplete - $($unreadableScopes.ToArray() -join ', ') policies could not be read."
-    }
-
-    if ($safetyFindings.Count -eq 0 -and $unreadableScopes.Count -eq 0) {
-        Write-Step 'Safety: no protected Brave policy names detected.'
-    }
-    elseif ($safetyFindings.Count -gt 0) {
-        foreach ($finding in $safetyFindings) {
-            Write-Warning "Safety: $finding"
-        }
-    }
-
-    $braveProcesses = @(Get-Process -Name brave -ErrorAction SilentlyContinue)
-    if ($braveProcesses.Count -gt 0) {
-        Write-Step "Brave process: running ($($braveProcesses.Count) process(es)). Profile preference cleanup would be skipped."
-    }
-    else {
-        Write-Step 'Brave process: not running.'
-    }
-
-    $profileFiles = @(Get-BraveProfilePreferenceFiles -Root $ProfileRoot)
-    if (Test-Path -LiteralPath $ProfileRoot) {
-        Write-Step "Profile root: found ($($profileFiles.Count) Preferences file(s)) - $ProfileRoot"
-    }
-    else {
-        Write-Step "Profile root: missing - $ProfileRoot"
-    }
-
-    $backupSummary = Get-BackupSummary -Directory $BackupDirectory
-    Write-Step "Backups: $($backupSummary.Count) found in $($backupSummary.Directory)"
-    if (-not [string]::IsNullOrWhiteSpace($backupSummary.Latest)) {
-        Write-Step "Latest backup: $($backupSummary.Latest)"
-    }
-
-    $currentUserPolicies = Get-PolicyEntryMap -Entries $currentUserReport.Entries
-    $localMachinePolicies = Get-PolicyEntryMap -Entries $localMachineReport.Entries
-
-    Write-Step 'Policy scopes:'
-    $scopeRows = foreach ($report in $reports) {
-        $status = 'Missing'
-        if (-not $report.CanRead) {
-            $status = 'Read failed'
-        }
-        elseif ($report.Entries.Count -gt 0) {
-            $status = 'Found'
-        }
-        elseif ($report.KeyExists) {
-            $status = 'Empty'
-        }
-
-        [pscustomobject]@{
-            Scope = $report.Scope
-            Status = $status
-            Values = $report.Entries.Count
-            Path = $report.Path
-        }
-    }
-    $scopeRows | Format-Table -AutoSize -Wrap
-
-    Write-Step 'Feature status:'
-    $featureRows = foreach ($feature in @($Features)) {
-        [pscustomobject]@{
-            Feature = [string]$feature.id
-            CurrentUser = if (-not $currentUserReport.CanRead) { 'Read failed' } else { Get-FeaturePolicyStatus -Feature $feature -PolicyEntries $currentUserPolicies -PolicyDefinitions $PolicyDefinitions }
-            LocalMachine = if (-not $localMachineReport.CanRead) { 'Read failed' } else { Get-FeaturePolicyStatus -Feature $feature -PolicyEntries $localMachinePolicies -PolicyDefinitions $PolicyDefinitions }
-            Label = [string]$feature.label
-        }
-    }
-    $featureRows | Format-Table -AutoSize -Wrap
-
-    $unknownRows = New-Object System.Collections.Generic.List[object]
-    foreach ($report in $reports) {
-        foreach ($entry in @($report.Entries)) {
-            if (-not $PolicyDefinitions.ContainsKey([string]$entry.Name)) {
-                [void]$unknownRows.Add([pscustomobject]@{
-                        Scope = $report.Scope
-                        Policy = [string]$entry.Name
-                        Value = $entry.Value
-                        Kind = [string]$entry.Kind
-                    })
-            }
-        }
-    }
-
-    if ($unknownRows.Count -gt 0) {
-        Write-Step 'Unknown Brave policies: detected. These may have been set by Brave, another tool, or an organization.'
-        $unknownRows.ToArray() | Format-Table -AutoSize -Wrap
-    }
-    else {
-        Write-Step 'Unknown Brave policies: none detected.'
-    }
+$moduleDir = Join-Path $ProjectRoot 'src'
+foreach ($moduleName in @('Common.ps1', 'Manifest.ps1', 'PlatformPolicy.ps1', 'Backup.ps1', 'ProfilePreferences.ps1', 'Reports.ps1')) {
+    . (Join-Path $moduleDir $moduleName)
 }
 
 $manifest = Get-Manifest
+$platformName = Resolve-PlatformName -Name $Platform
+if ([string]::IsNullOrWhiteSpace($ProfileRoot)) {
+    $ProfileRoot = Get-DefaultProfileRoot -PlatformName $platformName
+}
 $applyChanges = $Apply -and -not $WhatIfPreference
 $isWhatIf = $Apply -and $WhatIfPreference
 
 if ($UndoFromBackup) {
-    Restore-RegistryBackup -BackupPath $UndoFromBackup -Manifest $manifest -ProfileRoot $ProfileRoot -DoApply:$applyChanges
+    Restore-RegistryBackup -BackupPath $UndoFromBackup -Manifest $manifest -ProfileRoot $ProfileRoot -AllowedPolicyPath $PolicyPath -DoApply:$applyChanges
     if (-not $applyChanges) {
         if ($isWhatIf) {
-            Write-Step 'Undo WhatIf complete. Rerun with -Apply without -WhatIf to restore the backup.'
+            Write-Step 'Undo preview complete. No files or policies were restored. Rerun with -Apply without -WhatIf to restore the backup.'
         }
         else {
-            Write-Step 'Undo dry-run complete. Rerun with -Apply to restore the backup.'
+            Write-Step 'Undo dry-run complete. No files or policies were restored. Rerun with -Apply to restore the backup.'
         }
     }
     else {
-        Write-Step 'Undo complete. Restart Brave, then open brave://policy to verify.'
+        Write-Step 'Undo complete. Restart Brave, then open brave://policy to check the restored policies.'
     }
     return
 }
@@ -1311,9 +94,9 @@ Assert-FeatureReferences -Features $features -PolicyDefinitions $policyDefinitio
 
 if ($Doctor) {
     if ($Apply) {
-        Write-Warning '-Doctor is read-only. -Apply is ignored in Doctor mode.'
+        Write-Warning '-Doctor is read-only. -Apply was ignored. No policy, backup, or profile files will be changed.'
     }
-    Show-DoctorReport -Manifest $manifest -Features $features -PolicyDefinitions $policyDefinitions -ProfileRoot $ProfileRoot -BackupDirectory $BackupDirectory
+    Show-DoctorReport -Manifest $manifest -Features $features -PolicyDefinitions $policyDefinitions -ProfileRoot $ProfileRoot -BackupDirectory $BackupDirectory -PlatformName $platformName -PolicyPath $PolicyPath
     return
 }
 
@@ -1322,7 +105,7 @@ $normalizedIncludeFeature = @(Get-NormalizedFeatureName -Names $IncludeFeature)
 $normalizedExcludeFeature = @(Get-NormalizedFeatureName -Names $ExcludeFeature)
 
 if ($PSBoundParameters.ContainsKey('OnlyFeature') -and $normalizedOnlyFeature.Count -eq 0) {
-    throw 'Specified -OnlyFeature contains only blank entries; please provide a valid feature name.'
+    throw 'Specified -OnlyFeature contains only blank entries. Add at least one feature name, for example: -OnlyFeature Rewards'
 }
 
 Assert-FeatureNames -Names $normalizedIncludeFeature -FeatureMap $featureMap
@@ -1330,13 +113,13 @@ Assert-FeatureNames -Names $normalizedExcludeFeature -FeatureMap $featureMap
 Assert-FeatureNames -Names $normalizedOnlyFeature -FeatureMap $featureMap
 foreach ($featureName in $normalizedIncludeFeature) {
     if ($normalizedExcludeFeature -contains $featureName) {
-        throw "Feature '$featureName' cannot be both included and excluded."
+        throw "Feature '$featureName' is in both -IncludeFeature and -ExcludeFeature. Pick one list for that feature."
     }
 }
 
 $onlyFeatureMode = $normalizedOnlyFeature.Count -gt 0
 if ($onlyFeatureMode -and ($Customize -or $normalizedIncludeFeature.Count -gt 0 -or $normalizedExcludeFeature.Count -gt 0)) {
-    throw '-OnlyFeature cannot be combined with -Customize, -IncludeFeature, or -ExcludeFeature.'
+    throw '-OnlyFeature cannot be combined with -Customize, -IncludeFeature, or -ExcludeFeature. Use -OnlyFeature by itself when you want an exact feature list.'
 }
 
 $policyNames = New-Object System.Collections.Generic.List[string]
@@ -1363,7 +146,7 @@ if ($LockShields) {
 
 foreach ($policyName in $policyNames) {
     if (-not $policyDefinitions.ContainsKey($policyName)) {
-        throw "Policy '$policyName' is referenced by a preset but not defined."
+        throw "Policy '$policyName' is listed in a preset but missing from config/policies.json."
     }
 }
 
@@ -1377,7 +160,7 @@ if ($ListFeatures) {
 if ($List) {
     Show-PolicyList -PolicyNames $policyNames.ToArray() -PolicyDefinitions $policyDefinitions
     if ($IncludeProfilePreferences) {
-        Write-Step 'Profile preference patches:'
+        Write-Step 'Profile preference patches that would be considered:'
         $patchesToList = @($manifest.profilePreferencePatches)
         if ($customFeatureRequested) {
             $patchesToList = @($patchesToList | Where-Object {
@@ -1390,7 +173,18 @@ if ($List) {
     return
 }
 
-$registryPath = Get-RegistryBasePath -ScopeName $Scope
+$policyTarget = Get-PolicyTarget -PlatformName $platformName -ScopeName $Scope -OverridePath $PolicyPath
+if ($policyTarget.Kind -eq 'MobileMDM' -and $applyChanges) {
+    throw "$platformName policies require MDM deployment. This script can list or export the selected policies, but it cannot apply them on-device."
+}
+
+if (-not [string]::IsNullOrWhiteSpace($ExportPolicyPath)) {
+    Assert-MobilePolicySupport -PlatformName $platformName -PolicyNames $policyNames.ToArray() -Manifest $manifest
+    $payload = Get-PolicyPayload -PolicyNames $policyNames.ToArray() -PolicyDefinitions $policyDefinitions
+    Export-PolicyPayload -Target $policyTarget -Payload $payload -Path $ExportPolicyPath
+    Write-Step "Exported $($policyNames.Count) policy value(s) for $platformName to $ExportPolicyPath. Apply that file with your device or policy manager."
+    return
+}
 
 if ($onlyFeatureMode) {
     Write-Step 'Preset: (none - OnlyFeature mode)'
@@ -1398,12 +192,13 @@ if ($onlyFeatureMode) {
 else {
     Write-Step "Preset: $Preset"
 }
-Write-Step "Scope: $Scope ($registryPath)"
+Write-Step "Platform: $platformName"
+Write-Step "Scope: $Scope ($($policyTarget.Path))"
 if ($LockShields) {
-    Write-Step 'Shield baseline: enabled. This enforces ad blocking, standard fingerprinting protection, HTTPS upgrade, and referrer capping.'
+    Write-Step 'Shield baseline: enabled. Brave will keep ad blocking, standard fingerprinting protection, HTTPS upgrades, and referrer capping on by policy.'
 }
 else {
-    Write-Step 'Shield baseline: not locked. This tool will not disable or whitelist Brave Shields.'
+    Write-Step 'Shield baseline: not locked. This run will still refuse policies that disable or whitelist Brave Shields.'
 }
 if ($customFeatureRequested) {
     Write-Step "Custom features: $($selectedFeatureIds -join ', ')"
@@ -1411,20 +206,21 @@ if ($customFeatureRequested) {
 
 if (-not $applyChanges) {
     if ($isWhatIf) {
-        Write-Step 'WhatIf mode. No registry, backup, or profile files will be changed.'
+        Write-Step 'WhatIf mode. No policy, backup, or profile files will be changed.'
     }
     else {
-        Write-Step 'Dry-run mode. No registry, backup, or profile files will be changed.'
+        Write-Step 'Dry-run mode. No policy, backup, or profile files will be changed.'
     }
+    Write-Step 'Review the [dry-run] lines. Add -Apply only when the planned changes look right.'
 }
 
 if ($IncludeProfilePreferences -and $applyChanges -and $NoBackup) {
-    throw 'Profile preference cleanup requires backups. Remove -NoBackup or omit -IncludeProfilePreferences.'
+    throw 'Profile preference cleanup requires backups. Remove -NoBackup, or omit -IncludeProfilePreferences and apply policy-only changes.'
 }
 
 $backupPath = $null
 if ($applyChanges -and -not $NoBackup) {
-    $backupPath = New-Backup -Directory $BackupDirectory -ScopeName $Scope -RegistryPath $registryPath -PolicyNames $policyNames.ToArray() -ProfileRoot $ProfileRoot -Manifest $manifest
+    $backupPath = New-Backup -Directory $BackupDirectory -ScopeName $Scope -Target $policyTarget -PolicyNames $policyNames.ToArray() -ProfileRoot $ProfileRoot -Manifest $manifest
     Write-Step "Backup written to $backupPath"
 }
 
@@ -1435,8 +231,8 @@ foreach ($policyName in $policyNames) {
         continue
     }
 
-    if ($PSCmdlet.ShouldProcess($registryPath, "Set $policyName to $($definition.value)")) {
-        Set-BravePolicy -BasePath $registryPath -Name $policyName -Definition $definition
+    if ($PSCmdlet.ShouldProcess($policyTarget.Path, "Set $policyName to $($definition.value)")) {
+        Set-PolicyValue -Target $policyTarget -Name $policyName -Definition $definition
         Write-Step "Set $policyName."
     }
 }
@@ -1447,12 +243,12 @@ if ($IncludeProfilePreferences) {
 
 if (-not $applyChanges) {
     if ($isWhatIf) {
-        Write-Step 'WhatIf complete. Rerun with -Apply without -WhatIf to make changes.'
+        Write-Step 'WhatIf complete. No changes were made. Rerun with -Apply without -WhatIf when you are ready.'
     }
     else {
-        Write-Step 'Dry-run complete. Rerun with -Apply to make changes.'
+        Write-Step 'Dry-run complete. No changes were made. Rerun with -Apply when you are ready.'
     }
 }
 else {
-    Write-Step 'Done. Restart Brave, then open brave://policy to verify the applied policies.'
+    Write-Step 'Done. Restart Brave, then open brave://policy to check the applied policies.'
 }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ![Brave](https://img.shields.io/badge/Brave-FB542B?style=flat-square&logo=brave&logoColor=white)
 ![Windows](https://img.shields.io/badge/Windows-0078D4?style=flat-square&logo=windows&logoColor=white)
+![macOS](https://img.shields.io/badge/macOS-000000?style=flat-square&logo=apple&logoColor=white)
+![Linux](https://img.shields.io/badge/Linux-FCC624?style=flat-square&logo=linux&logoColor=black)
 ![PowerShell](https://img.shields.io/badge/PowerShell-5391FE?style=flat-square&logo=powershell&logoColor=white)
 [![CI](https://img.shields.io/github/actions/workflow/status/osfv/BraveDebloater/ci.yml?branch=main&style=flat-square&logo=githubactions&logoColor=white&label=CI)](https://github.com/osfv/BraveDebloater/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/osfv/BraveDebloater?style=flat-square&label=license)](LICENSE)
@@ -12,73 +14,88 @@
 
 <p>
   <img src="assets/icons/brave.svg" width="18" alt="Brave logo" />
-  <strong>BraveDebloater</strong> is a safety-first Windows PowerShell tool for trimming Brave Browser extras while keeping Brave Shields intact.
+  <strong>BraveDebloater</strong> removes Brave Browser extras with Brave and Chromium enterprise policies.
 </p>
 
 <p>
-  <img src="assets/icons/windows.svg" width="16" alt="Windows logo" /> Windows-first
+  <img src="assets/icons/windows.svg" width="16" alt="Windows logo" /> Windows/macOS/Linux
   &nbsp;·&nbsp;
-  <img src="assets/icons/powershell.svg" width="16" alt="PowerShell logo" /> PowerShell-native
+  <img src="assets/icons/powershell.svg" width="16" alt="PowerShell logo" /> PowerShell runtime
   &nbsp;·&nbsp;
   <img src="assets/icons/opensource.svg" width="16" alt="Open Source Initiative logo" /> Open source
 </p>
 
-It uses official Brave/Chromium enterprise policies where possible, starts in dry-run mode, writes backups before applying changes, and includes an undo path. No updater disabling, no host-file edits, no extension removal, and no Shield allowlisting.
+The script starts in preview mode. Nothing changes until you add `-Apply`.
 
-## What It Debloats
+Before an apply run, BraveDebloater writes a backup unless you use `-NoBackup` for policy-only changes. It does not disable Brave updates, edit hosts files, remove extensions, turn off Brave Shields, or add Shield allowlists.
 
-- Brave Rewards, Wallet, VPN, Leo AI Chat, News, Talk, Playlist, Speedreader, and Wayback prompts
-- Brave telemetry surfaces such as P3A, stats ping, and Web Discovery
-- Chromium metrics, URL-keyed collection, Privacy Sandbox prompts, remote search suggestions, network prediction, and remote spellcheck
-- Extreme preset extras such as background mode, promotions, Browser Labs, new tab cards, shopping list, QR generator, translate prompts, autofill, and the Google search side panel
+PowerShell is the cross-platform runtime. The files it writes are native to each platform: Windows registry policies, macOS defaults or plist payloads, and Linux JSON policy files.
 
-Optional profile preference cleanup can also hide some new tab sponsored/background and toolbar surfaces when Brave stores those preferences in per-profile `Preferences` JSON.
+## What It Can Remove
 
-## Quick Start
+Brave-specific surfaces:
 
-Preview the extreme preset:
+- Rewards, Wallet, VPN, Leo AI Chat, News, Talk, Playlist, Email Aliases, IPFS, Speedreader, and Wayback prompts
+
+Telemetry and suggestions:
+
+- Brave P3A, stats ping, Web Discovery, Chromium metrics, URL-keyed collection, Privacy Sandbox prompts, remote search suggestions, network prediction, and remote spellcheck
+
+Extra UI in the `Extreme` preset:
+
+- Background mode, promotions, Browser Labs, new tab cards, shopping list, QR generator, translate prompts, autofill, and the Google search side panel
+
+Optional profile preference cleanup can also hide some new tab, sponsored background, and toolbar surfaces. That part edits per-profile `Preferences` JSON, so close Brave before applying it.
+
+## Start Here
+
+Preview the default cleanup first:
 
 ```powershell
 .\Invoke-BraveDebloat.ps1 -Preset Extreme
 ```
 
-List the policies and optional profile preference patches without running the dry-run/apply flow:
-
-```powershell
-.\Invoke-BraveDebloat.ps1 -Preset Extreme -List -IncludeProfilePreferences
-```
-
-List the available feature toggles:
-
-```powershell
-.\Invoke-BraveDebloat.ps1 -ListFeatures
-```
-
-Run a read-only health check of Brave policies, backups, profile files, and detected feature status:
-
-```powershell
-.\Invoke-BraveDebloat.ps1 -Doctor
-```
-
-Apply it for the current Windows user:
+Read the output. If it looks right, apply it:
 
 ```powershell
 .\Invoke-BraveDebloat.ps1 -Preset Extreme -Apply
 ```
 
-Apply it and enforce a safe Shields baseline:
+After applying, restart Brave. Then open `brave://policy` and check that the policies loaded.
+
+## Common Tasks
+
+See what would be changed, including profile preference patches:
+
+```powershell
+.\Invoke-BraveDebloat.ps1 -Preset Extreme -List -IncludeProfilePreferences
+```
+
+See the feature names you can include or exclude:
+
+```powershell
+.\Invoke-BraveDebloat.ps1 -ListFeatures
+```
+
+Run a read-only health check:
+
+```powershell
+.\Invoke-BraveDebloat.ps1 -Doctor
+```
+
+Apply the default cleanup and lock a safe Shields baseline:
 
 ```powershell
 .\Invoke-BraveDebloat.ps1 -Preset Extreme -LockShields -Apply
 ```
 
-Customize the preset interactively:
+Choose features one by one:
 
 ```powershell
 .\Invoke-BraveDebloat.ps1 -Preset Extreme -Customize
 ```
 
-Or make a scripted custom run:
+Use exact feature choices in scripts:
 
 ```powershell
 .\Invoke-BraveDebloat.ps1 -Preset Extreme -ExcludeFeature News,LeoAI
@@ -86,47 +103,79 @@ Or make a scripted custom run:
 .\Invoke-BraveDebloat.ps1 -OnlyFeature Rewards,Wallet,VPN
 ```
 
-PowerShell `-WhatIf` is supported as a no-write preview even when `-Apply` is present:
+Use PowerShell `-WhatIf` when you want a no-write preview even with `-Apply` present:
 
 ```powershell
 .\Invoke-BraveDebloat.ps1 -Preset Extreme -Apply -WhatIf
 ```
 
-After applying, restart Brave and open `brave://policy` to verify the policies.
+## Platform Support
+
+Windows writes Brave policy values under the current-user or local-machine registry policy key.
+
+macOS current-user mode uses `defaults write com.brave.Browser`. macOS machine-wide mode writes `/Library/Managed Preferences/com.brave.Browser.plist`.
+
+Linux writes JSON policy values to `/etc/brave/policies/managed/BraveDebloater.json`.
+
+Android and iOS/iPadOS do not support local writes from this script. Use `-ExportPolicyPath` to create an MDM payload. Brave documents limited iOS/iPadOS support for Playlist, VPN, News, Talk, Rewards, and AI Chat policies.
+
+Examples:
+
+```powershell
+.\Invoke-BraveDebloat.ps1 -Platform macOS -Preset Extreme -Apply
+.\Invoke-BraveDebloat.ps1 -Platform Linux -Preset Extreme -Apply
+.\Invoke-BraveDebloat.ps1 -Platform Linux -Preset Extreme -ExportPolicyPath .\brave-policy.json
+.\Invoke-BraveDebloat.ps1 -Platform iOS -OnlyFeature Rewards -ExportPolicyPath .\brave-ios.mobileconfig
+.\Invoke-BraveDebloat.ps1 -Platform Android -OnlyFeature Rewards -ExportPolicyPath .\brave-android-mdm.json
+```
+
+Use `-PolicyPath` when testing, or when your managed Linux/macOS policy file lives somewhere custom.
 
 ## Presets
 
-- `Standard`: Brave-specific bloat and Brave telemetry.
-- `High`: `Standard` plus privacy-preserving policy defaults.
-- `Extreme`: `High` plus more UI and convenience surface cleanup.
-- `Core`, `Privacy`, and `Aggressive`: compatibility aliases for `Standard`, `High`, and `Extreme`.
-- `-LockShields`: optional add-on that enforces default ad blocking, standard fingerprinting protection, HTTPS upgrades, and stricter referrer behavior.
+`Standard` removes Brave-specific bloat and Brave telemetry.
 
-By default, the tool uses `Extreme` and does not lock Shield behavior. It also refuses to apply policies that disable Shields, add Shield-disabled URLs, weaken Safe Browsing, or disable updates.
+`High` includes `Standard` and adds privacy-preserving policy defaults.
+
+`Extreme` includes `High` and removes more UI and convenience surfaces.
+
+`Core`, `Privacy`, and `Aggressive` are aliases for `Standard`, `High`, and `Extreme`.
+
+`-LockShields` is an optional add-on. It enforces default ad blocking, standard fingerprinting protection, HTTPS upgrades, and stricter referrer behavior.
+
+By default, the tool uses `Extreme` and does not lock Shields. It refuses to apply policies that disable Shields, add Shield-disabled URLs, weaken Safe Browsing, or disable updates.
 
 ## Feature Toggles
 
-Use `-Customize` for an interactive yes/no prompt for each cleanup, or use `-IncludeFeature` and `-ExcludeFeature` for repeatable commands. Feature names are shown by `-ListFeatures`; examples include `Rewards`, `Wallet`, `VPN`, `LeoAI`, `News`, `Talk`, `Autofill`, `Translate`, and `GoogleSearchSidePanel`.
+Use `-Customize` for an interactive yes/no prompt for each cleanup.
+
+Use `-IncludeFeature` and `-ExcludeFeature` for repeatable commands.
 
 Use `-OnlyFeature` when you want exactly the named cleanups without starting from a preset.
+
+Feature names are shown by `-ListFeatures`. Examples include `Rewards`, `Wallet`, `VPN`, `LeoAI`, `News`, `Talk`, `EmailAliases`, `IPFS`, `Autofill`, `Translate`, and `GoogleSearchSidePanel`.
 
 When `-IncludeProfilePreferences` is combined with custom feature choices, profile preference patches are filtered to the selected features.
 
 ## Doctor Mode
 
-Use `-Doctor` to inspect the current Brave policy state without writing anything. It reports CurrentUser and LocalMachine policy keys, detected feature status, unknown Brave policies, protected policy names, Brave process state, profile preference files, and available backups.
+Use `-Doctor` when you want to inspect Brave without changing anything.
 
-This is useful after testing other debloat tools because machine-wide policies can make Brave settings appear managed for every Windows user.
+It checks policy locations, detected feature status, unknown Brave policies, protected policy names, Brave process state, profile preference files, and backups.
+
+This helps after testing other debloat tools. Machine-wide policies can make Brave settings appear managed for every Windows user, even when current-user policies look empty.
 
 ## Profile Preferences
 
-Registry policies are the main path because they are supported and visible in `brave://policy`. For cosmetic cleanup that Brave stores per profile, close Brave and run:
+Policies are the main path because Brave shows them in `brave://policy`.
+
+Some cosmetic cleanup lives in each Brave profile instead. Close Brave first, then run:
 
 ```powershell
 .\Invoke-BraveDebloat.ps1 -Preset Extreme -IncludeProfilePreferences -Apply
 ```
 
-If Brave is running, profile preference cleanup is skipped to avoid writing files that Brave may overwrite.
+If Brave is running, profile preference cleanup is skipped. This avoids writing files that Brave may overwrite.
 
 ## Restore
 
@@ -144,11 +193,13 @@ Apply a restore:
 .\Invoke-BraveDebloat.ps1 -UndoFromBackup .\backups\BraveDebloater-YYYYMMDD-HHMMSS-fff.json -Apply
 ```
 
-Restore validates backup metadata before writing. Registry restores are limited to Brave policy keys, and profile file restores are limited to `Preferences` files under the selected `-ProfileRoot`.
+Restore validates the backup before it writes. Registry restores are limited to Brave policy keys. Profile file restores are limited to `Preferences` files under the selected `-ProfileRoot`.
 
 ## Machine-Wide Mode
 
-Current-user policy is the default and does not require administrator rights. For machine-wide policy, run PowerShell as administrator:
+Current-user policy is the default and does not require administrator/root rights.
+
+For machine-wide policy, run PowerShell as administrator/root:
 
 ```powershell
 .\Invoke-BraveDebloat.ps1 -Preset Extreme -Scope LocalMachine -Apply
@@ -156,20 +207,28 @@ Current-user policy is the default and does not require administrator rights. Fo
 
 ## Sources
 
-Policy names and values are based on Brave's official Group Policy documentation and Brave policy templates:
+Policy names and values come from Brave's official Group Policy documentation and Brave policy templates:
 
 - https://support.brave.app/hc/en-us/articles/360039248271-Group-Policy
 - https://brave-browser-downloads.s3.brave.com/latest/policy_templates.zip
 
+See `docs/debloatable-validation.md` for the source version, the policy choices, and the validation commands.
+
 ## Project Checks
 
-Run the built-in manifest and syntax checks:
+Run the local checks:
 
 ```powershell
 .\scripts\Test-PolicyManifest.ps1
 .\scripts\Test-Behavior.ps1
 ```
 
+Validate against a downloaded Brave policy template zip:
+
+```powershell
+.\scripts\Test-LatestPolicyTemplates.ps1 -TemplateZipPath .\policy_templates.zip
+```
+
 ## Pull Request Review
 
-Greptile review guidance lives in `greptile.json` and mirrors the same safety-first focus for PowerShell compatibility, policy changes, registry writes, profile JSON writes, and feature-toggle behavior.
+Greptile review guidance lives in `greptile.json`. It covers PowerShell compatibility, policy writes, registry writes, profile JSON writes, and feature-toggle behavior.

--- a/config/policies.json
+++ b/config/policies.json
@@ -1,10 +1,24 @@
 {
   "schemaVersion": 1,
-  "policyTemplateVersion": "148.1.91.121",
+  "policyTemplateVersion": "150.1.93.96",
   "sources": [
     "https://support.brave.app/hc/en-us/articles/360039248271-Group-Policy",
     "https://brave-browser-downloads.s3.brave.com/latest/policy_templates.zip"
   ],
+  "platformSupport": {
+    "Windows": "official-template",
+    "macOS": "official-template",
+    "Linux": "official-template",
+    "Android": "mdm-no-template",
+    "iOS": [
+      "BravePlaylistEnabled",
+      "BraveVPNDisabled",
+      "BraveNewsDisabled",
+      "BraveTalkDisabled",
+      "BraveRewardsDisabled",
+      "BraveAIChatEnabled"
+    ]
+  },
   "safety": {
     "blockedPolicyNames": [
       "BraveShieldsDisabledForUrls",
@@ -40,6 +54,8 @@
       "BraveNewsDisabled",
       "BraveTalkDisabled",
       "BravePlaylistEnabled",
+      "EmailAliasesEnabled",
+      "IPFSEnabled",
       "BraveSpeedreaderEnabled",
       "BraveWaybackMachineEnabled",
       "BraveP3AEnabled",
@@ -64,6 +80,7 @@
       "@Privacy",
       "BackgroundModeEnabled",
       "PromotionsEnabled",
+      "PromotionalTabsEnabled",
       "BrowserLabsEnabled",
       "MediaRecommendationsEnabled",
       "NTPCardsVisible",
@@ -139,6 +156,22 @@
         "BravePlaylistEnabled"
       ],
       "reason": "Disable Brave Playlist."
+    },
+    {
+      "id": "EmailAliases",
+      "label": "Email aliases",
+      "policies": [
+        "EmailAliasesEnabled"
+      ],
+      "reason": "Disable Brave Email Aliases entry points."
+    },
+    {
+      "id": "IPFS",
+      "label": "IPFS",
+      "policies": [
+        "IPFSEnabled"
+      ],
+      "reason": "Disable IPFS integration."
     },
     {
       "id": "Speedreader",
@@ -259,7 +292,8 @@
       "id": "Promotions",
       "label": "promotional surfaces",
       "policies": [
-        "PromotionsEnabled"
+        "PromotionsEnabled",
+        "PromotionalTabsEnabled"
       ],
       "reason": "Disable promotional surfaces."
     },
@@ -395,6 +429,18 @@
       "category": "Brave feature",
       "reason": "Disable Brave Playlist."
     },
+    "EmailAliasesEnabled": {
+      "type": "DWord",
+      "value": 0,
+      "category": "Brave feature",
+      "reason": "Disable Brave Email Aliases."
+    },
+    "IPFSEnabled": {
+      "type": "DWord",
+      "value": 0,
+      "category": "Brave feature",
+      "reason": "Disable IPFS integration."
+    },
     "BraveSpeedreaderEnabled": {
       "type": "DWord",
       "value": 0,
@@ -502,6 +548,12 @@
       "value": 0,
       "category": "UI",
       "reason": "Disable promotional surfaces."
+    },
+    "PromotionalTabsEnabled": {
+      "type": "DWord",
+      "value": 0,
+      "category": "UI",
+      "reason": "Disable promotional tabs."
     },
     "BrowserLabsEnabled": {
       "type": "DWord",

--- a/docs/debloatable-validation.md
+++ b/docs/debloatable-validation.md
@@ -1,0 +1,84 @@
+# Debloatable Source Validation
+
+BraveDebloater only adds policy names that can be checked against Brave's own policy sources.
+
+## Source Files
+
+Official sources used for this pass:
+
+- Brave Help Center, Group Policy, updated February 12, 2026: https://support.brave.app/hc/en-us/articles/360039248271-Group-Policy
+- Latest Brave policy templates zip: https://brave-browser-downloads.s3.brave.com/latest/policy_templates.zip
+
+Downloaded template evidence:
+
+- Template version: `150.1.93.96`
+- Archive timestamp: June 23, 2026
+- Checked files: `VERSION` and `windows/admx/brave.admx`
+
+Targeted Reddit, Brave Community, and GitHub searches did not produce a newer or more authoritative debloatable-policy source than Brave's Help Center and template zip.
+
+## What Changed
+
+The manifest version in `config/policies.json` changed from `148.1.91.121` to `150.1.93.96`.
+
+These official-template policies were added because they match BraveDebloater's scope:
+
+- `EmailAliasesEnabled = 0`
+- `IPFSEnabled = 0`
+- `PromotionalTabsEnabled = 0`
+
+These official-template policies were checked and left out:
+
+- `TorDisabled`: disables a privacy feature instead of removing bloat.
+- `DefaultBraveRemember1PStorageSetting`: changes storage behavior instead of removing an extra surface.
+- `BraveShieldsDisabledForUrls` and `BraveShieldsEnabledForUrls`: Shield URL lists stay blocked by the safety rules.
+
+## Platform Notes
+
+`Windows`, `macOS`, and `Linux` are validated from the official Brave ADMX template. Brave documents desktop support for Chromium policies plus Brave-specific policies, and documents native policy storage for macOS and Linux.
+
+`Android` is marked `mdm-no-template`. Brave documents Android as MDM-controlled and says it does not currently provide MDM templates for Android.
+
+`iOS` is limited to the Brave-documented mobile policy list:
+
+- `BravePlaylistEnabled`
+- `BraveVPNDisabled`
+- `BraveNewsDisabled`
+- `BraveTalkDisabled`
+- `BraveRewardsDisabled`
+- `BraveAIChatEnabled`
+
+iOS/iPadOS export validation now reads that allow-list from the manifest instead of a hardcoded list.
+
+## New Check
+
+`scripts/Test-LatestPolicyTemplates.ps1` validates a downloaded official template zip.
+
+It checks that:
+
+- the manifest version matches the zip `VERSION`;
+- every manifest policy exists in `windows/admx/brave.admx`;
+- every iOS allow-listed policy is defined in the manifest.
+
+## Validation Commands
+
+Download the current Brave template zip:
+
+```powershell
+curl -L -o /tmp/brave-policy-templates.zip https://brave-browser-downloads.s3.brave.com/latest/policy_templates.zip
+```
+
+Run the source-backed template check:
+
+```powershell
+pwsh -NoProfile -File ./scripts/Test-LatestPolicyTemplates.ps1 -TemplateZipPath /tmp/brave-policy-templates.zip
+```
+
+Run the local checks:
+
+```powershell
+pwsh -NoProfile -File ./scripts/Test-PolicyManifest.ps1
+pwsh -NoProfile -File ./scripts/Test-Behavior.ps1
+```
+
+The template validator uses a local zip file on purpose. CI can download the current zip before running it, but normal offline checks do not need network access.

--- a/scripts/Test-Behavior.ps1
+++ b/scripts/Test-Behavior.ps1
@@ -210,8 +210,8 @@ try {
         throw 'Linux policy apply did not create the policy JSON file.'
     }
     $linuxPolicyJson = Get-Content -LiteralPath $linuxPolicyPath -Raw | ConvertFrom-Json
-    if ([int]$linuxPolicyJson.BraveRewardsDisabled -ne 1) {
-        throw 'Linux policy apply did not write BraveRewardsDisabled = 1.'
+    if ($linuxPolicyJson.BraveRewardsDisabled -isnot [bool] -or -not $linuxPolicyJson.BraveRewardsDisabled) {
+        throw 'Linux policy apply did not write BraveRewardsDisabled = true.'
     }
 
     $customLinuxBackup = Join-Path $tempRoot 'custom-linux-backup.json'
@@ -254,8 +254,8 @@ try {
     $androidExportOutput = (& $scriptPath -Platform Android -OnlyFeature Rewards -ExportPolicyPath $androidPolicyPath *>&1 | Out-String)
     Assert-TextContains -Text $androidExportOutput -Expected 'Exported 1 policy value(s) for Android' -Context 'Android export output'
     $androidPolicyJson = Get-Content -LiteralPath $androidPolicyPath -Raw | ConvertFrom-Json
-    if ([int]$androidPolicyJson.BraveRewardsDisabled -ne 1) {
-        throw 'Android policy export did not write BraveRewardsDisabled = 1.'
+    if ($androidPolicyJson.BraveRewardsDisabled -isnot [bool] -or -not $androidPolicyJson.BraveRewardsDisabled) {
+        throw 'Android policy export did not write BraveRewardsDisabled = true.'
     }
 
     $iosPolicyPath = Join-Path $tempRoot 'brave-ios.mobileconfig'
@@ -264,6 +264,7 @@ try {
     $iosMobileConfig = Get-Content -LiteralPath $iosPolicyPath -Raw
     Assert-TextContains -Text $iosMobileConfig -Expected 'com.apple.ManagedClient.preferences' -Context 'iOS mobileconfig'
     Assert-TextContains -Text $iosMobileConfig -Expected 'BraveRewardsDisabled' -Context 'iOS mobileconfig'
+    Assert-TextContains -Text $iosMobileConfig -Expected '<true/>' -Context 'iOS mobileconfig'
 
     $iosUnsupportedFailed = $false
     try {

--- a/scripts/Test-Behavior.ps1
+++ b/scripts/Test-Behavior.ps1
@@ -62,7 +62,7 @@ try {
 
     $doctorApplyBackupDirectory = Join-Path $tempRoot 'DoctorApplyBackups'
     $doctorApplyOutput = (& $scriptPath -Doctor -Apply -ProfileRoot $missingProfileRoot -BackupDirectory $doctorApplyBackupDirectory *>&1 | Out-String)
-    Assert-TextContains -Text $doctorApplyOutput -Expected '-Doctor is read-only. -Apply is ignored in Doctor mode.' -Context '-Doctor -Apply output'
+    Assert-TextContains -Text $doctorApplyOutput -Expected '-Doctor is read-only. -Apply was ignored. No policy, backup, or profile files will be changed.' -Context '-Doctor -Apply output'
     Assert-TextContains -Text $doctorApplyOutput -Expected 'Doctor report (read-only)' -Context '-Doctor -Apply output'
     Assert-TextDoesNotContain -Text $doctorApplyOutput -Unexpected 'Backup written' -Context '-Doctor -Apply output'
     Assert-TextDoesNotContain -Text $doctorApplyOutput -Unexpected 'Would set' -Context '-Doctor -Apply output'
@@ -131,7 +131,7 @@ try {
 
     $whatIfBackupDirectory = Join-Path $tempRoot 'WhatIfBackups'
     $whatIfOutput = (& $scriptPath -Preset Core -Apply -WhatIf -BackupDirectory $whatIfBackupDirectory *>&1 | Out-String)
-    Assert-TextContains -Text $whatIfOutput -Expected 'WhatIf mode. No registry, backup, or profile files will be changed.' -Context '-WhatIf output'
+    Assert-TextContains -Text $whatIfOutput -Expected 'WhatIf mode. No policy, backup, or profile files will be changed.' -Context '-WhatIf output'
     Assert-TextDoesNotContain -Text $whatIfOutput -Unexpected 'Backup written' -Context '-WhatIf output'
     Assert-TextDoesNotContain -Text $whatIfOutput -Unexpected 'Done. Restart Brave' -Context '-WhatIf output'
     if (Test-Path -LiteralPath $whatIfBackupDirectory) {
@@ -200,6 +200,80 @@ try {
     $invalidJsonContentBefore = Get-Content -LiteralPath $invalidPreferences -Raw
     if ($invalidJsonContentBefore -ne '{ this is not valid json') {
         throw 'Dry-run modified an invalid profile Preferences file.'
+    }
+
+    $linuxPolicyPath = Join-Path $tempRoot 'BraveDebloater-linux-policy.json'
+    $linuxApplyOutput = (& $scriptPath -Platform Linux -PolicyPath $linuxPolicyPath -OnlyFeature Rewards -Apply -NoBackup *>&1 | Out-String)
+    Assert-TextContains -Text $linuxApplyOutput -Expected 'Platform: Linux' -Context 'Linux policy apply output'
+    Assert-TextContains -Text $linuxApplyOutput -Expected 'Set BraveRewardsDisabled.' -Context 'Linux policy apply output'
+    if (-not (Test-Path -LiteralPath $linuxPolicyPath)) {
+        throw 'Linux policy apply did not create the policy JSON file.'
+    }
+    $linuxPolicyJson = Get-Content -LiteralPath $linuxPolicyPath -Raw | ConvertFrom-Json
+    if ([int]$linuxPolicyJson.BraveRewardsDisabled -ne 1) {
+        throw 'Linux policy apply did not write BraveRewardsDisabled = 1.'
+    }
+
+    $customLinuxBackup = Join-Path $tempRoot 'custom-linux-backup.json'
+    [ordered]@{
+        schemaVersion = 1
+        platform = 'Linux'
+        policyKind = 'JsonFile'
+        registryPath = $linuxPolicyPath
+        policies = @(
+            [ordered]@{
+                name = 'BraveRewardsDisabled'
+                existed = $false
+                value = $null
+                kind = $null
+            }
+        )
+        profileFiles = @()
+    } | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $customLinuxBackup -Encoding UTF8
+
+    $customRestoreRejected = $false
+    try {
+        & $scriptPath -UndoFromBackup $customLinuxBackup | Out-Null
+    }
+    catch {
+        $customRestoreRejected = $_.Exception.Message -match 'untrusted registry path'
+    }
+    if (-not $customRestoreRejected) {
+        throw 'Custom Linux backup restore did not require the matching -PolicyPath.'
+    }
+
+    $customRestoreOutput = (& $scriptPath -UndoFromBackup $customLinuxBackup -PolicyPath $linuxPolicyPath *>&1 | Out-String)
+    Assert-TextContains -Text $customRestoreOutput -Expected 'Would remove BraveRewardsDisabled' -Context 'custom Linux restore dry-run output'
+
+    $androidDryRunOutput = (& $scriptPath -Platform Android -OnlyFeature Rewards *>&1 | Out-String)
+    Assert-TextContains -Text $androidDryRunOutput -Expected 'Platform: Android' -Context 'Android dry-run output'
+    Assert-TextContains -Text $androidDryRunOutput -Expected 'MDM profile' -Context 'Android dry-run output'
+    Assert-TextContains -Text $androidDryRunOutput -Expected 'Would set BraveRewardsDisabled' -Context 'Android dry-run output'
+
+    $androidPolicyPath = Join-Path $tempRoot 'brave-android-mdm.json'
+    $androidExportOutput = (& $scriptPath -Platform Android -OnlyFeature Rewards -ExportPolicyPath $androidPolicyPath *>&1 | Out-String)
+    Assert-TextContains -Text $androidExportOutput -Expected 'Exported 1 policy value(s) for Android' -Context 'Android export output'
+    $androidPolicyJson = Get-Content -LiteralPath $androidPolicyPath -Raw | ConvertFrom-Json
+    if ([int]$androidPolicyJson.BraveRewardsDisabled -ne 1) {
+        throw 'Android policy export did not write BraveRewardsDisabled = 1.'
+    }
+
+    $iosPolicyPath = Join-Path $tempRoot 'brave-ios.mobileconfig'
+    $iosExportOutput = (& $scriptPath -Platform iOS -OnlyFeature Rewards -ExportPolicyPath $iosPolicyPath *>&1 | Out-String)
+    Assert-TextContains -Text $iosExportOutput -Expected 'Exported 1 policy value(s) for iOS' -Context 'iOS export output'
+    $iosMobileConfig = Get-Content -LiteralPath $iosPolicyPath -Raw
+    Assert-TextContains -Text $iosMobileConfig -Expected 'com.apple.ManagedClient.preferences' -Context 'iOS mobileconfig'
+    Assert-TextContains -Text $iosMobileConfig -Expected 'BraveRewardsDisabled' -Context 'iOS mobileconfig'
+
+    $iosUnsupportedFailed = $false
+    try {
+        & $scriptPath -Platform iOS -Preset Extreme -ExportPolicyPath (Join-Path $tempRoot 'unsupported.mobileconfig') | Out-Null
+    }
+    catch {
+        $iosUnsupportedFailed = $_.Exception.Message -match 'unsupported selected policies'
+    }
+    if (-not $iosUnsupportedFailed) {
+        throw 'iOS export did not reject unsupported policies.'
     }
 
     Write-Host 'Behavior checks passed.'

--- a/scripts/Test-Behavior.ps1
+++ b/scripts/Test-Behavior.ps1
@@ -52,8 +52,17 @@ try {
 
     $doctorOutput = (& $scriptPath -Doctor -ProfileRoot $missingProfileRoot -BackupDirectory $doctorBackupDirectory *>&1 | Out-String)
     Assert-TextContains -Text $doctorOutput -Expected 'Doctor report (read-only)' -Context '-Doctor output'
-    Assert-TextContains -Text $doctorOutput -Expected 'CurrentUser policies' -Context '-Doctor output'
     Assert-TextContains -Text $doctorOutput -Expected 'LocalMachine policies' -Context '-Doctor output'
+    # Linux exposes a single machine-wide managed policy file, so both scopes resolve to the
+    # same path and the report lists it once. Platforms with a distinct user scope still show both.
+    $isLinuxPlatform = $false
+    $isLinuxVariable = Get-Variable -Name IsLinux -Scope Global -ErrorAction SilentlyContinue
+    if ($isLinuxVariable -and $isLinuxVariable.Value) {
+        $isLinuxPlatform = $true
+    }
+    if (-not $isLinuxPlatform) {
+        Assert-TextContains -Text $doctorOutput -Expected 'CurrentUser policies' -Context '-Doctor output'
+    }
     Assert-TextContains -Text $doctorOutput -Expected 'Feature status' -Context '-Doctor output'
     Assert-TextContains -Text $doctorOutput -Expected 'Backups: 1 found' -Context '-Doctor output'
     Assert-TextContains -Text $doctorOutput -Expected 'Profile root: missing' -Context '-Doctor output'
@@ -276,6 +285,20 @@ try {
     if (-not $iosUnsupportedFailed) {
         throw 'iOS export did not reject unsupported policies.'
     }
+
+    $iosDryRunRejected = $false
+    try {
+        & $scriptPath -Platform iOS -Preset Extreme | Out-Null
+    }
+    catch {
+        $iosDryRunRejected = $_.Exception.Message -match 'unsupported selected policies'
+    }
+    if (-not $iosDryRunRejected) {
+        throw 'iOS dry-run did not reject unsupported policies.'
+    }
+
+    $iosSupportedDryRun = (& $scriptPath -Platform iOS -OnlyFeature Rewards *>&1 | Out-String)
+    Assert-TextContains -Text $iosSupportedDryRun -Expected 'Would set BraveRewardsDisabled' -Context 'iOS supported dry-run output'
 
     Write-Host 'Behavior checks passed.'
 }

--- a/scripts/Test-LatestPolicyTemplates.ps1
+++ b/scripts/Test-LatestPolicyTemplates.ps1
@@ -1,0 +1,79 @@
+#requires -Version 5.1
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$TemplateZipPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$root = Split-Path -Parent $PSScriptRoot
+$manifestPath = Join-Path $root 'config\policies.json'
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+function Read-ZipEntryText {
+    param(
+        [Parameter(Mandatory = $true)]$Zip,
+        [Parameter(Mandatory = $true)][string]$EntryName
+    )
+
+    $entry = $Zip.GetEntry($EntryName)
+    if ($null -eq $entry) {
+        throw "Template zip is missing '$EntryName'."
+    }
+
+    $stream = $entry.Open()
+    try {
+        $reader = New-Object System.IO.StreamReader($stream, $true)
+        try {
+            return $reader.ReadToEnd()
+        }
+        finally {
+            $reader.Dispose()
+        }
+    }
+    finally {
+        $stream.Dispose()
+    }
+}
+
+if (-not (Test-Path -LiteralPath $TemplateZipPath)) {
+    throw "Missing template zip: $TemplateZipPath"
+}
+
+$manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+$zip = [System.IO.Compression.ZipFile]::OpenRead((Resolve-Path -LiteralPath $TemplateZipPath))
+try {
+    $versionText = Read-ZipEntryText -Zip $zip -EntryName 'VERSION'
+    $templateVersion = (($versionText -split "`n") | ForEach-Object { $_.Trim() } | Where-Object { $_ -match '^(MAJOR|MINOR|BUILD|PATCH)=' }) -replace '^[^=]+='
+    $templateVersion = $templateVersion -join '.'
+    if ($templateVersion -ne [string]$manifest.policyTemplateVersion) {
+        throw "Manifest policyTemplateVersion '$($manifest.policyTemplateVersion)' does not match template '$templateVersion'."
+    }
+
+    $admx = Read-ZipEntryText -Zip $zip -EntryName 'windows/admx/brave.admx'
+    $templatePolicies = @([regex]::Matches($admx, '<policy\b[^>]*\bname="([^"]+)"') |
+        ForEach-Object { $_.Groups[1].Value } |
+        Where-Object { $_ -notmatch '_recommended$' } |
+        Sort-Object -Unique)
+
+    foreach ($policyName in @($manifest.policies.PSObject.Properties.Name)) {
+        if ($templatePolicies -notcontains $policyName) {
+            throw "Manifest policy '$policyName' is not present in the official Brave ADMX template."
+        }
+    }
+
+    $iosSupported = @($manifest.platformSupport.iOS)
+    foreach ($policyName in $iosSupported) {
+        if ($null -eq $manifest.policies.PSObject.Properties[$policyName]) {
+            throw "iOS platform support references undefined policy '$policyName'."
+        }
+    }
+}
+finally {
+    $zip.Dispose()
+}
+
+Write-Host "Latest Brave template validation passed for $($manifest.policyTemplateVersion)."

--- a/scripts/Test-LatestPolicyTemplates.ps1
+++ b/scripts/Test-LatestPolicyTemplates.ps1
@@ -9,7 +9,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $root = Split-Path -Parent $PSScriptRoot
-$manifestPath = Join-Path $root 'config\policies.json'
+$manifestPath = Join-Path (Join-Path $root 'config') 'policies.json'
 
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 

--- a/scripts/Test-PolicyManifest.ps1
+++ b/scripts/Test-PolicyManifest.ps1
@@ -73,6 +73,22 @@ $features = @($manifest.features)
 $featureIds = New-Object System.Collections.Generic.List[string]
 $blockedNames = @($manifest.safety.blockedPolicyNames)
 $blockedPatterns = @($manifest.safety.blockedNamePatterns)
+$platformSupport = Get-ObjectMap -Object $manifest.platformSupport
+
+foreach ($platformName in @('Windows', 'macOS', 'Linux', 'Android', 'iOS')) {
+    if (-not $platformSupport.ContainsKey($platformName)) {
+        throw "Manifest platformSupport is missing '$platformName'."
+    }
+}
+
+foreach ($platformName in @('Windows', 'macOS', 'Linux')) {
+    if ([string]$platformSupport[$platformName] -ne 'official-template') {
+        throw "Manifest platformSupport '$platformName' must be 'official-template'."
+    }
+}
+if ([string]$platformSupport['Android'] -ne 'mdm-no-template') {
+    throw "Manifest platformSupport 'Android' must be 'mdm-no-template'."
+}
 
 foreach ($presetName in $presets.Keys) {
     foreach ($policyName in Resolve-Preset -Name $presetName -Presets $presets) {
@@ -106,6 +122,12 @@ foreach ($policyName in $policies.Keys) {
     }
     if ($policy.type -eq 'DWord' -and ([long]$policy.value -lt 0 -or [long]$policy.value -gt [uint32]::MaxValue)) {
         throw "Policy '$policyName' has DWord value outside the registry range: $($policy.value)."
+    }
+}
+
+foreach ($policyName in @($platformSupport['iOS'])) {
+    if (-not $policies.ContainsKey([string]$policyName)) {
+        throw "Manifest platformSupport iOS references undefined policy '$policyName'."
     }
 }
 

--- a/scripts/Test-PolicyManifest.ps1
+++ b/scripts/Test-PolicyManifest.ps1
@@ -6,7 +6,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 $root = Split-Path -Parent $PSScriptRoot
-$manifestPath = Join-Path $root 'config\policies.json'
+$manifestPath = Join-Path (Join-Path $root 'config') 'policies.json'
 $scriptPath = Join-Path $root 'Invoke-BraveDebloat.ps1'
 
 function Get-ObjectMap {

--- a/src/Backup.ps1
+++ b/src/Backup.ps1
@@ -55,7 +55,7 @@ function Assert-BackupPolicyList {
             }
 
             $value = Get-RequiredPropertyValue -Object $policy -Name 'value' -Context "Backup policy '$name'"
-            if ($kind -eq 'DWord' -and $value -isnot [int] -and $value -isnot [long]) {
+            if ($kind -eq 'DWord' -and $value -isnot [int] -and $value -isnot [long] -and $value -isnot [bool]) {
                 throw "Backup policy '$name' is DWord but has non-integer value '$value'."
             }
             if ($kind -eq 'String' -and $value -isnot [string]) {

--- a/src/Backup.ps1
+++ b/src/Backup.ps1
@@ -1,0 +1,276 @@
+#requires -Version 5.1
+
+function Assert-BackupRegistryPath {
+    param(
+        [Parameter(Mandatory = $true)][string]$RegistryPath,
+        [string]$AllowedPolicyPath,
+        [switch]$DoApply
+    )
+
+    $allowedPaths = @(
+        'Registry::HKEY_CURRENT_USER\Software\Policies\BraveSoftware\Brave',
+        'Registry::HKEY_LOCAL_MACHINE\Software\Policies\BraveSoftware\Brave',
+        '/etc/brave/policies/managed/BraveDebloater.json',
+        '/Library/Managed Preferences/com.brave.Browser.plist',
+        'com.brave.Browser'
+    )
+
+    if ($allowedPaths -notcontains $RegistryPath -and $RegistryPath -ne $AllowedPolicyPath) {
+        throw "Backup contains untrusted registry path '$RegistryPath'. Restore stopped before writing anything."
+    }
+
+    if ($DoApply -and $RegistryPath -ieq 'Registry::HKEY_LOCAL_MACHINE\Software\Policies\BraveSoftware\Brave' -and -not (Test-IsAdministrator)) {
+        throw 'Restoring a LocalMachine backup needs an elevated PowerShell session. Reopen PowerShell as administrator/root, then rerun the restore command.'
+    }
+}
+
+function Assert-BackupPolicyList {
+    param(
+        [Parameter(Mandatory = $true)]$Backup,
+        [Parameter(Mandatory = $true)][hashtable]$PolicyDefinitions
+    )
+
+    if ($null -eq $Backup.PSObject.Properties['policies']) {
+        throw "Backup is missing required property 'policies'."
+    }
+
+    foreach ($policy in @($Backup.policies)) {
+        $name = [string](Get-RequiredPropertyValue -Object $policy -Name 'name' -Context 'Backup policy')
+        $existed = Get-RequiredPropertyValue -Object $policy -Name 'existed' -Context "Backup policy '$name'"
+
+        if (-not ($existed -is [bool])) {
+            throw "Backup policy '$name' has a non-boolean 'existed' value."
+        }
+        if (-not $PolicyDefinitions.ContainsKey($name)) {
+            throw "Backup policy '$name' is not managed by this manifest."
+        }
+
+        if ($existed) {
+            $kind = [string](Get-RequiredPropertyValue -Object $policy -Name 'kind' -Context "Backup policy '$name'")
+            if (@('DWord', 'String') -notcontains $kind) {
+                throw "Backup policy '$name' has unsupported registry kind '$kind'."
+            }
+            if ($kind -ne [string]$PolicyDefinitions[$name].type) {
+                throw "Backup policy '$name' registry kind '$kind' does not match the manifest type '$($PolicyDefinitions[$name].type)'."
+            }
+
+            $value = Get-RequiredPropertyValue -Object $policy -Name 'value' -Context "Backup policy '$name'"
+            if ($kind -eq 'DWord' -and $value -isnot [int] -and $value -isnot [long]) {
+                throw "Backup policy '$name' is DWord but has non-integer value '$value'."
+            }
+            if ($kind -eq 'String' -and $value -isnot [string]) {
+                throw "Backup policy '$name' is String but has non-string value '$value'."
+            }
+        }
+    }
+}
+
+function Assert-BackupProfileFile {
+    param(
+        [Parameter(Mandatory = $true)]$ProfileFile,
+        [Parameter(Mandatory = $true)][string]$BackupPath,
+        [Parameter(Mandatory = $true)][string]$ProfileRoot
+    )
+
+    $source = [string](Get-RequiredPropertyValue -Object $ProfileFile -Name 'backupPath' -Context 'Backup profile file')
+    $target = [string](Get-RequiredPropertyValue -Object $ProfileFile -Name 'originalPath' -Context 'Backup profile file')
+    $backupDirectory = Split-Path -Parent (Get-FullFileSystemPath -Path $BackupPath)
+    $profileBackupDirectory = Join-Path $backupDirectory 'profile-files'
+
+    # Profile restores should only read files created beside the selected backup.
+    if (-not (Test-PathIsUnderDirectory -Path $source -Directory $profileBackupDirectory)) {
+        throw "Backup profile source is outside the expected backup folder: $source"
+    }
+
+    # Profile restores should only write Brave Preferences files under the selected profile root.
+    if (-not (Test-PathIsUnderDirectory -Path $target -Directory $ProfileRoot)) {
+        throw "Backup profile target is outside the selected profile root: $target"
+    }
+    if ((Split-Path -Leaf $target) -ne 'Preferences') {
+        throw "Backup profile target is not a Brave Preferences file: $target"
+    }
+}
+
+function Assert-BackupObject {
+    param(
+        [Parameter(Mandatory = $true)]$Backup,
+        [Parameter(Mandatory = $true)]$Manifest,
+        [Parameter(Mandatory = $true)][string]$BackupPath,
+        [Parameter(Mandatory = $true)][string]$ProfileRoot,
+        [string]$AllowedPolicyPath,
+        [switch]$DoApply
+    )
+
+    $schemaVersion = Get-RequiredPropertyValue -Object $Backup -Name 'schemaVersion' -Context 'Backup'
+    if ($schemaVersion -ne 1) {
+        throw "Unsupported backup schema version '$schemaVersion'."
+    }
+
+    $registryPath = [string](Get-RequiredPropertyValue -Object $Backup -Name 'registryPath' -Context 'Backup')
+    Assert-BackupRegistryPath -RegistryPath $registryPath -AllowedPolicyPath $AllowedPolicyPath -DoApply:$DoApply
+
+    $policyDefinitions = Get-ManifestMap -Object $Manifest.policies
+    Assert-BackupPolicyList -Backup $Backup -PolicyDefinitions $policyDefinitions
+
+    $profileFiles = @()
+    if ($null -ne $Backup.PSObject.Properties['profileFiles']) {
+        $profileFiles = @($Backup.profileFiles)
+    }
+
+    foreach ($profileFile in $profileFiles) {
+        Assert-BackupProfileFile -ProfileFile $profileFile -BackupPath $BackupPath -ProfileRoot $ProfileRoot
+    }
+}
+
+function Get-BackupSummary {
+    param([string]$Directory)
+
+    $fullDirectory = Get-FullFileSystemPath -Path $Directory
+    $files = @()
+    if (Test-Path -LiteralPath $fullDirectory) {
+        $files = @(Get-ChildItem -LiteralPath $fullDirectory -Filter 'BraveDebloater-*.json' | Where-Object { -not $_.PSIsContainer } | Sort-Object LastWriteTime -Descending)
+    }
+
+    $latest = ''
+    if ($files.Count -gt 0) {
+        $latest = $files[0].FullName
+    }
+
+    return [pscustomobject]@{
+        Directory = $fullDirectory
+        Count = $files.Count
+        Latest = $latest
+    }
+}
+
+function New-BackupPath {
+    param([string]$Directory)
+
+    $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss-fff'
+    $path = Join-Path $Directory "BraveDebloater-$timestamp.json"
+    if (-not (Test-Path -LiteralPath $path)) {
+        return $path
+    }
+
+    $suffix = [guid]::NewGuid().ToString('N').Substring(0, 8)
+    return (Join-Path $Directory "BraveDebloater-$timestamp-$suffix.json")
+}
+
+function New-Backup {
+    param(
+        [string]$Directory,
+        [string]$ScopeName,
+        [Parameter(Mandatory = $true)]$Target,
+        [string[]]$PolicyNames,
+        [string]$ProfileRoot,
+        [Parameter(Mandatory = $true)]$Manifest
+    )
+
+    $Directory = Get-FullFileSystemPath -Path $Directory
+    if (-not (Test-Path -LiteralPath $Directory)) {
+        New-Item -ItemType Directory -Path $Directory -Force | Out-Null
+    }
+
+    $path = New-BackupPath -Directory $Directory
+    $backup = [ordered]@{
+        schemaVersion = 1
+        createdAt = (Get-Date).ToString('o')
+        manifestSchemaVersion = $Manifest.schemaVersion
+        policyTemplateVersion = $Manifest.policyTemplateVersion
+        scope = $ScopeName
+        platform = $Target.Platform
+        policyKind = $Target.Kind
+        registryPath = $Target.Path
+        profileRoot = $ProfileRoot
+        policies = @(Get-PolicySnapshot -Target $Target -PolicyNames $PolicyNames)
+        profileFiles = @()
+    }
+
+    Set-JsonFileContent -Path $path -Object $backup -Depth 20
+    return $path
+}
+
+function Update-BackupProfileFiles {
+    param(
+        [string]$BackupPath,
+        [object[]]$ProfileFiles
+    )
+
+    if (-not $BackupPath -or -not (Test-Path -LiteralPath $BackupPath)) {
+        return
+    }
+
+    $backup = Get-Content -LiteralPath $BackupPath -Raw | ConvertFrom-Json
+    $backup.profileFiles = @($ProfileFiles)
+    Set-JsonFileContent -Path $BackupPath -Object $backup -Depth 20
+}
+
+function Restore-RegistryBackup {
+    param(
+        [string]$BackupPath,
+        [Parameter(Mandatory = $true)]$Manifest,
+        [Parameter(Mandatory = $true)][string]$ProfileRoot,
+        [string]$AllowedPolicyPath,
+        [switch]$DoApply
+    )
+
+    if (-not (Test-Path -LiteralPath $BackupPath)) {
+        throw "Backup file not found: $BackupPath. Check the path, then rerun the restore command."
+    }
+
+    $backup = Get-Content -LiteralPath $BackupPath -Raw | ConvertFrom-Json
+    Assert-BackupObject -Backup $backup -Manifest $Manifest -BackupPath $BackupPath -ProfileRoot $ProfileRoot -AllowedPolicyPath $AllowedPolicyPath -DoApply:$DoApply
+    $policyTarget = [pscustomobject]@{
+        Platform = if ($backup.PSObject.Properties['platform']) { [string]$backup.platform } else { 'Windows' }
+        Kind = if ($backup.PSObject.Properties['policyKind']) { [string]$backup.policyKind } else { 'Registry' }
+        Path = [string]$backup.registryPath
+    }
+
+    foreach ($policy in @($backup.policies)) {
+        $name = [string]$policy.name
+        $existed = [bool]$policy.existed
+        if (-not $DoApply) {
+            if ($existed) {
+                Write-DryRun "Would restore $name to '$($policy.value)' ($($policy.kind))."
+            }
+            else {
+                Write-DryRun "Would remove $name because it did not exist before."
+            }
+            continue
+        }
+
+        if ($existed) {
+            $kind = [string]$policy.kind
+            $value = $policy.value
+            $definition = [pscustomobject]@{ type = $kind; value = $value }
+            Set-PolicyValue -Target $policyTarget -Name $name -Definition $definition
+            Write-Step "Restored $name."
+        }
+        else {
+            Remove-PolicyValue -Target $policyTarget -Name $name
+            Write-Step "Removed $name."
+        }
+    }
+
+    foreach ($profileFile in @($backup.profileFiles)) {
+        $source = [string]$profileFile.backupPath
+        $target = [string]$profileFile.originalPath
+
+        if (-not $DoApply) {
+            Write-DryRun "Would restore profile file $target."
+            continue
+        }
+
+        if (Test-Path -LiteralPath $source) {
+            $targetDirectory = Split-Path -Parent $target
+            if (-not (Test-Path -LiteralPath $targetDirectory)) {
+                New-Item -ItemType Directory -Path $targetDirectory -Force | Out-Null
+            }
+            Copy-Item -LiteralPath $source -Destination $target -Force
+            Write-Step "Restored profile file $target."
+        }
+        else {
+            Write-Warning "Profile backup file is missing, so this profile file was not restored: $source"
+        }
+    }
+}

--- a/src/Common.ps1
+++ b/src/Common.ps1
@@ -1,0 +1,114 @@
+#requires -Version 5.1
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host "[BraveDebloater] $Message"
+}
+
+function Write-DryRun {
+    param([string]$Message)
+    Write-Host "[dry-run] $Message"
+}
+
+function Get-ManifestMap {
+    param([Parameter(Mandatory = $true)]$Object)
+
+    $map = @{}
+    foreach ($property in $Object.PSObject.Properties) {
+        $map[$property.Name] = $property.Value
+    }
+    return $map
+}
+
+function Add-StringIfMissing {
+    param(
+        [Parameter(Mandatory = $true)]$List,
+        [Parameter(Mandatory = $true)][string]$Value
+    )
+
+    if (-not $List.Contains($Value)) {
+        [void]$List.Add($Value)
+    }
+}
+
+function Remove-StringFromList {
+    param(
+        [Parameter(Mandatory = $true)]$List,
+        [Parameter(Mandatory = $true)][string]$Value
+    )
+
+    while ($List.Remove($Value)) {
+    }
+}
+
+function Get-FullFileSystemPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        throw 'Expected a non-empty filesystem path.'
+    }
+
+    try {
+        return [System.IO.Path]::GetFullPath($ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Path))
+    }
+    catch {
+        return [System.IO.Path]::GetFullPath($Path)
+    }
+}
+
+function Test-PathIsUnderDirectory {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Directory
+    )
+
+    $fullPath = Get-FullFileSystemPath -Path $Path
+    $fullDirectory = Get-FullFileSystemPath -Path $Directory
+    $separator = [System.IO.Path]::DirectorySeparatorChar
+
+    if (-not $fullDirectory.EndsWith([string]$separator, [StringComparison]::OrdinalIgnoreCase)) {
+        $fullDirectory = "$fullDirectory$separator"
+    }
+
+    return $fullPath.StartsWith($fullDirectory, [StringComparison]::OrdinalIgnoreCase)
+}
+
+function Get-RequiredPropertyValue {
+    param(
+        [Parameter(Mandatory = $true)]$Object,
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Context
+    )
+
+    $property = $Object.PSObject.Properties[$Name]
+    if ($null -eq $property) {
+        throw "$Context is missing required property '$Name'."
+    }
+
+    return $property.Value
+}
+
+function Set-JsonFileContent {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)]$Object,
+        [int]$Depth = 20
+    )
+
+    $directory = Split-Path -Parent $Path
+    if (-not [string]::IsNullOrWhiteSpace($directory) -and -not (Test-Path -LiteralPath $directory)) {
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    }
+
+    $tempDirectory = if ([string]::IsNullOrWhiteSpace($directory)) { '.' } else { $directory }
+    $tempPath = Join-Path $tempDirectory ('.{0}.tmp' -f [guid]::NewGuid().ToString('N'))
+    try {
+        $Object | ConvertTo-Json -Depth $Depth | Set-Content -LiteralPath $tempPath -Encoding UTF8
+        Move-Item -LiteralPath $tempPath -Destination $Path -Force
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempPath) {
+            Remove-Item -LiteralPath $tempPath -Force
+        }
+    }
+}

--- a/src/Common.ps1
+++ b/src/Common.ps1
@@ -112,3 +112,27 @@ function Set-JsonFileContent {
         }
     }
 }
+
+function Set-TextFileContent {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Content
+    )
+
+    $directory = Split-Path -Parent $Path
+    if (-not [string]::IsNullOrWhiteSpace($directory) -and -not (Test-Path -LiteralPath $directory)) {
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    }
+
+    $tempDirectory = if ([string]::IsNullOrWhiteSpace($directory)) { '.' } else { $directory }
+    $tempPath = Join-Path $tempDirectory ('.{0}.tmp' -f [guid]::NewGuid().ToString('N'))
+    try {
+        Set-Content -LiteralPath $tempPath -Value $Content -Encoding UTF8
+        Move-Item -LiteralPath $tempPath -Destination $Path -Force
+    }
+    finally {
+        if (Test-Path -LiteralPath $tempPath) {
+            Remove-Item -LiteralPath $tempPath -Force
+        }
+    }
+}

--- a/src/Manifest.ps1
+++ b/src/Manifest.ps1
@@ -1,7 +1,7 @@
 #requires -Version 5.1
 
 function Get-Manifest {
-    $manifestPath = Join-Path $ProjectRoot 'config\policies.json'
+    $manifestPath = Join-Path (Join-Path $ProjectRoot 'config') 'policies.json'
     if (-not (Test-Path -LiteralPath $manifestPath)) {
         throw "Cannot find policy manifest at $manifestPath."
     }

--- a/src/Manifest.ps1
+++ b/src/Manifest.ps1
@@ -1,0 +1,292 @@
+#requires -Version 5.1
+
+function Get-Manifest {
+    $manifestPath = Join-Path $ProjectRoot 'config\policies.json'
+    if (-not (Test-Path -LiteralPath $manifestPath)) {
+        throw "Cannot find policy manifest at $manifestPath."
+    }
+
+    return Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+}
+
+function Resolve-PresetPolicies {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][hashtable]$Presets,
+        [hashtable]$Seen = @{}
+    )
+
+    if (-not $Presets.ContainsKey($Name)) {
+        throw "Unknown preset '$Name'."
+    }
+    if ($Seen.ContainsKey($Name)) {
+        throw "Preset cycle detected at '$Name'."
+    }
+
+    $Seen[$Name] = $true
+    $resolved = New-Object System.Collections.Generic.List[string]
+
+    foreach ($entry in @($Presets[$Name])) {
+        if ($entry -isnot [string]) {
+            throw "Preset '$Name' contains a non-string entry."
+        }
+
+        if ($entry.StartsWith('@')) {
+            $childName = $entry.Substring(1)
+            foreach ($childPolicy in Resolve-PresetPolicies -Name $childName -Presets $Presets -Seen ($Seen.Clone())) {
+                if (-not $resolved.Contains($childPolicy)) {
+                    [void]$resolved.Add($childPolicy)
+                }
+            }
+        }
+        elseif (-not $resolved.Contains($entry)) {
+            [void]$resolved.Add($entry)
+        }
+    }
+
+    return $resolved.ToArray()
+}
+
+function Get-FeatureMap {
+    param([object[]]$Features)
+
+    $map = @{}
+    foreach ($feature in @($Features)) {
+        $id = [string]$feature.id
+        if ([string]::IsNullOrWhiteSpace($id)) {
+            throw 'Feature entry is missing an id.'
+        }
+        if ($map.ContainsKey($id)) {
+            throw "Duplicate feature id '$id'."
+        }
+        $map[$id] = $feature
+    }
+    return $map
+}
+
+function Get-FeaturePolicies {
+    param([Parameter(Mandatory = $true)]$Feature)
+
+    return @($Feature.policies) | ForEach-Object { [string]$_ }
+}
+
+function Test-FeatureSelectedByPolicy {
+    param(
+        [Parameter(Mandatory = $true)]$Feature,
+        [Parameter(Mandatory = $true)]$PolicyNames,
+        [Parameter(Mandatory = $true)][string]$PresetName
+    )
+
+    $policies = @(Get-FeaturePolicies -Feature $Feature)
+    if ($policies.Count -eq 0) {
+        return (@($Feature.defaultPresets) -contains $PresetName)
+    }
+
+    foreach ($policyName in $policies) {
+        if (-not $PolicyNames.Contains($policyName)) {
+            return $false
+        }
+    }
+    return $true
+}
+
+function Assert-FeatureNames {
+    param(
+        [string[]]$Names,
+        [Parameter(Mandatory = $true)][hashtable]$FeatureMap
+    )
+
+    foreach ($name in @($Names)) {
+        if ([string]::IsNullOrWhiteSpace([string]$name)) {
+            continue
+        }
+        if (-not $FeatureMap.ContainsKey($name)) {
+            $available = ($FeatureMap.Keys | Sort-Object) -join ', '
+            throw "Unknown feature '$name'. Run -ListFeatures to see descriptions. Available feature names: $available"
+        }
+    }
+}
+
+function Get-NormalizedFeatureName {
+    param([string[]]$Names)
+
+    $normalized = New-Object System.Collections.Generic.List[string]
+    foreach ($name in @($Names)) {
+        $trimmed = ([string]$name).Trim()
+        if ([string]::IsNullOrWhiteSpace($trimmed)) {
+            continue
+        }
+        Add-StringIfMissing -List $normalized -Value $trimmed
+    }
+    return $normalized.ToArray()
+}
+
+function Assert-FeatureReferences {
+    param(
+        [object[]]$Features,
+        [Parameter(Mandatory = $true)][hashtable]$PolicyDefinitions
+    )
+
+    foreach ($feature in @($Features)) {
+        foreach ($policyName in Get-FeaturePolicies -Feature $feature) {
+            if (-not $PolicyDefinitions.ContainsKey($policyName)) {
+                throw "Feature '$($feature.id)' references undefined policy '$policyName'."
+            }
+        }
+    }
+}
+
+function Set-FeatureSelection {
+    param(
+        [Parameter(Mandatory = $true)]$Feature,
+        [Parameter(Mandatory = $true)]$PolicyNames,
+        [Parameter(Mandatory = $true)]$SelectedFeatureIds,
+        [Parameter(Mandatory = $true)][bool]$Selected
+    )
+
+    $featureId = [string]$Feature.id
+    if ($Selected) {
+        Add-StringIfMissing -List $SelectedFeatureIds -Value $featureId
+        foreach ($policyName in Get-FeaturePolicies -Feature $Feature) {
+            Add-StringIfMissing -List $PolicyNames -Value $policyName
+        }
+        return
+    }
+
+    Remove-StringFromList -List $SelectedFeatureIds -Value $featureId
+    foreach ($policyName in Get-FeaturePolicies -Feature $Feature) {
+        Remove-StringFromList -List $PolicyNames -Value $policyName
+    }
+}
+
+function Read-FeatureChoice {
+    param(
+        [Parameter(Mandatory = $true)]$Feature,
+        [Parameter(Mandatory = $true)][bool]$Default
+    )
+
+    $defaultLabel = if ($Default) { 'Y/n' } else { 'y/N' }
+    $prompt = "Apply $($Feature.label) cleanup? [$defaultLabel]"
+    while ($true) {
+        $answer = (Read-Host $prompt).Trim()
+        if ([string]::IsNullOrWhiteSpace($answer)) {
+            return $Default
+        }
+        switch ($answer.ToLowerInvariant()) {
+            { $_ -in @('y', 'yes') } { return $true }
+            { $_ -in @('n', 'no') } { return $false }
+            default { Write-Host 'Please answer y or n.' }
+        }
+    }
+}
+
+function Resolve-FeatureSelection {
+    param(
+        [object[]]$Features,
+        [Parameter(Mandatory = $true)][hashtable]$FeatureMap,
+        [Parameter(Mandatory = $true)]$PolicyNames,
+        [Parameter(Mandatory = $true)][string]$PresetName,
+        [string[]]$IncludeNames,
+        [string[]]$ExcludeNames,
+        [switch]$UsePrompt
+    )
+
+    $selectedFeatureIds = New-Object System.Collections.Generic.List[string]
+    foreach ($feature in @($Features)) {
+        if (Test-FeatureSelectedByPolicy -Feature $feature -PolicyNames $PolicyNames -PresetName $PresetName) {
+            Add-StringIfMissing -List $selectedFeatureIds -Value ([string]$feature.id)
+        }
+    }
+
+    if ($UsePrompt) {
+        foreach ($feature in @($Features)) {
+            $default = $selectedFeatureIds.Contains([string]$feature.id)
+            $selected = Read-FeatureChoice -Feature $feature -Default $default
+            Set-FeatureSelection -Feature $feature -PolicyNames $PolicyNames -SelectedFeatureIds $selectedFeatureIds -Selected:$selected
+        }
+    }
+
+    foreach ($featureName in @($IncludeNames)) {
+        if ([string]::IsNullOrWhiteSpace([string]$featureName)) {
+            continue
+        }
+        Set-FeatureSelection -Feature $FeatureMap[$featureName] -PolicyNames $PolicyNames -SelectedFeatureIds $selectedFeatureIds -Selected:$true
+    }
+
+    foreach ($featureName in @($ExcludeNames)) {
+        if ([string]::IsNullOrWhiteSpace([string]$featureName)) {
+            continue
+        }
+        Set-FeatureSelection -Feature $FeatureMap[$featureName] -PolicyNames $PolicyNames -SelectedFeatureIds $selectedFeatureIds -Selected:$false
+    }
+
+    return $selectedFeatureIds.ToArray()
+}
+
+function Assert-PolicySafety {
+    param(
+        [string[]]$PolicyNames,
+        [Parameter(Mandatory = $true)]$Manifest
+    )
+
+    $blockedNames = @($Manifest.safety.blockedPolicyNames)
+    $blockedPatterns = @($Manifest.safety.blockedNamePatterns)
+
+    foreach ($policyName in $PolicyNames) {
+        if ($blockedNames -contains $policyName) {
+            throw "Refusing to apply protected policy '$policyName'."
+        }
+
+        foreach ($pattern in $blockedPatterns) {
+            if ($policyName -match $pattern) {
+                throw "Refusing to apply '$policyName' because it matches protected pattern '$pattern'."
+            }
+        }
+    }
+}
+
+function Assert-MobilePolicySupport {
+    param(
+        [string]$PlatformName,
+        [string[]]$PolicyNames,
+        [Parameter(Mandatory = $true)]$Manifest
+    )
+
+    if ($PlatformName -ne 'iOS') {
+        return
+    }
+
+    $supported = @($Manifest.platformSupport.iOS)
+
+    $unsupported = @($PolicyNames | Where-Object { $supported -notcontains $_ })
+    if ($unsupported.Count -gt 0) {
+        throw "iOS/iPadOS can export only Brave's documented mobile MDM policies. unsupported selected policies: $($unsupported -join ', '). Use -OnlyFeature Rewards, News, Talk, VPN, Playlist, or LeoAI, or export this preset for another platform."
+    }
+}
+
+function Get-PolicySafetyFinding {
+    param(
+        [string[]]$PolicyNames,
+        [Parameter(Mandatory = $true)]$Manifest
+    )
+
+    $findings = New-Object System.Collections.Generic.List[string]
+    $blockedNames = @($Manifest.safety.blockedPolicyNames)
+    $blockedPatterns = @($Manifest.safety.blockedNamePatterns)
+
+    foreach ($policyName in $PolicyNames) {
+        if ($blockedNames -contains $policyName) {
+            [void]$findings.Add("Protected policy '$policyName' is present.")
+            continue
+        }
+
+        foreach ($pattern in $blockedPatterns) {
+            if ($policyName -match $pattern) {
+                [void]$findings.Add("Policy '$policyName' matches protected pattern '$pattern'.")
+                break
+            }
+        }
+    }
+
+    return $findings.ToArray()
+}

--- a/src/PlatformPolicy.ps1
+++ b/src/PlatformPolicy.ps1
@@ -166,7 +166,11 @@ function Get-PolicyValue {
     if ($Target.Kind -eq 'MacOSDefaults' -or $Target.Kind -eq 'MacOSPlist') {
         $arguments = if ($Target.Kind -eq 'MacOSDefaults') { @('read', $Target.Path, $Name) } else { @('read', ($Target.Path -replace '\.plist$', ''), $Name) }
         $output = & /usr/bin/defaults @arguments 2>$null
-        if ($LASTEXITCODE -eq 0) {
+        $readSucceeded = $LASTEXITCODE -eq 0
+        # `defaults read` exits non-zero when the key is absent (the common case during a scan).
+        # Clear LASTEXITCODE so a missing key does not leak a failure exit code to the script.
+        $global:LASTEXITCODE = 0
+        if ($readSucceeded) {
             $text = $output -join "`n"
             $number = 0
             $value = if ([int]::TryParse($text, [ref]$number)) { $number } else { $text }
@@ -267,6 +271,8 @@ function Remove-PolicyValue {
     if ($Target.Kind -eq 'MacOSDefaults' -or $Target.Kind -eq 'MacOSPlist') {
         $domain = if ($Target.Kind -eq 'MacOSDefaults') { $Target.Path } else { $Target.Path -replace '\.plist$', '' }
         & /usr/bin/defaults delete $domain $Name 2>$null
+        # Deleting an absent key exits non-zero; clear it so the exit code is not leaked.
+        $global:LASTEXITCODE = 0
     }
 }
 

--- a/src/PlatformPolicy.ps1
+++ b/src/PlatformPolicy.ps1
@@ -202,7 +202,7 @@ function Set-PolicyValue {
         return
     }
 
-    $value = if ($Definition.type -eq 'DWord') { [int]$Definition.value } else { [string]$Definition.value }
+    $value = ConvertTo-ManagedPolicyValue -Definition $Definition
     if ($Target.Kind -eq 'JsonFile') {
         $json = [pscustomobject]@{}
         if (Test-Path -LiteralPath $Target.Path) {
@@ -220,7 +220,7 @@ function Set-PolicyValue {
 
     if ($Target.Kind -eq 'MacOSDefaults' -or $Target.Kind -eq 'MacOSPlist') {
         $domain = if ($Target.Kind -eq 'MacOSDefaults') { $Target.Path } else { $Target.Path -replace '\.plist$', '' }
-        $typeFlag = if ($Definition.type -eq 'DWord') { '-int' } else { '-string' }
+        $typeFlag = if ($value -is [bool]) { '-bool' } elseif ($value -is [int]) { '-int' } else { '-string' }
         if ($Target.Kind -eq 'MacOSPlist') {
             $directory = Split-Path -Parent $Target.Path
             if (-not (Test-Path -LiteralPath $directory)) {
@@ -386,6 +386,20 @@ function Test-PolicyValueMatches {
     return $false
 }
 
+function ConvertTo-ManagedPolicyValue {
+    param([Parameter(Mandatory = $true)]$Definition)
+
+    if ($Definition.type -eq 'DWord') {
+        $number = [int]$Definition.value
+        if ($number -eq 0 -or $number -eq 1) {
+            return [bool]$number
+        }
+        return $number
+    }
+
+    return [string]$Definition.value
+}
+
 function Get-FeaturePolicyStatus {
     param(
         [Parameter(Mandatory = $true)]$Feature,
@@ -433,7 +447,7 @@ function Get-PolicyPayload {
     $payload = [ordered]@{}
     foreach ($policyName in $PolicyNames) {
         $definition = $PolicyDefinitions[$policyName]
-        $payload[$policyName] = if ($definition.type -eq 'DWord') { [int]$definition.value } else { [string]$definition.value }
+        $payload[$policyName] = ConvertTo-ManagedPolicyValue -Definition $definition
     }
     return $payload
 }

--- a/src/PlatformPolicy.ps1
+++ b/src/PlatformPolicy.ps1
@@ -48,9 +48,12 @@ function Get-RegistryPolicyPath {
 }
 
 function Get-RegistryBasePath {
-    param([string]$ScopeName)
+    param(
+        [string]$ScopeName,
+        [switch]$ReadOnly
+    )
 
-    if ($ScopeName -eq 'LocalMachine') {
+    if ($ScopeName -eq 'LocalMachine' -and -not $ReadOnly) {
         if (-not (Test-IsAdministrator)) {
             throw 'LocalMachine scope needs an elevated PowerShell session. Use -Scope CurrentUser, or reopen PowerShell as administrator/root and run the command again.'
         }
@@ -63,12 +66,13 @@ function Get-PolicyTarget {
     param(
         [string]$PlatformName,
         [string]$ScopeName,
-        [string]$OverridePath
+        [string]$OverridePath,
+        [switch]$ReadOnly
     )
 
     switch ($PlatformName) {
         'Windows' {
-            return [pscustomobject]@{ Platform = $PlatformName; Kind = 'Registry'; Path = (Get-RegistryBasePath -ScopeName $ScopeName) }
+            return [pscustomobject]@{ Platform = $PlatformName; Kind = 'Registry'; Path = (Get-RegistryBasePath -ScopeName $ScopeName -ReadOnly:$ReadOnly) }
         }
         'Linux' {
             $path = if ([string]::IsNullOrWhiteSpace($OverridePath)) { '/etc/brave/policies/managed/BraveDebloater.json' } else { $OverridePath }
@@ -77,6 +81,9 @@ function Get-PolicyTarget {
         'macOS' {
             if ($ScopeName -eq 'LocalMachine') {
                 $path = if ([string]::IsNullOrWhiteSpace($OverridePath)) { '/Library/Managed Preferences/com.brave.Browser.plist' } else { $OverridePath }
+                if (-not $ReadOnly -and [string]::IsNullOrWhiteSpace($OverridePath) -and -not (Test-IsAdministrator)) {
+                    throw "macOS LocalMachine scope writes to '$path' and needs root. Use -Scope CurrentUser, or rerun the command with sudo."
+                }
                 return [pscustomobject]@{ Platform = $PlatformName; Kind = 'MacOSPlist'; Path = $path }
             }
             return [pscustomobject]@{ Platform = $PlatformName; Kind = 'MacOSDefaults'; Path = 'com.brave.Browser' }
@@ -557,7 +564,8 @@ function Export-PolicyPayload {
     }
 
     $mobileConfig = $Target.Platform -eq 'iOS' -or $Path.EndsWith('.mobileconfig', [StringComparison]::OrdinalIgnoreCase)
-    ConvertTo-PlistDocument -Payload $Payload -MobileConfig:$mobileConfig | Set-Content -LiteralPath $Path -Encoding UTF8
+    $document = ConvertTo-PlistDocument -Payload $Payload -MobileConfig:$mobileConfig
+    Set-TextFileContent -Path $Path -Content $document
 }
 
 function Set-BravePolicy {

--- a/src/PlatformPolicy.ps1
+++ b/src/PlatformPolicy.ps1
@@ -1,0 +1,572 @@
+#requires -Version 5.1
+
+function Test-IsAdministrator {
+    $isWindowsVariable = Get-Variable -Name IsWindows -Scope Global -ErrorAction SilentlyContinue
+    if ($isWindowsVariable -and -not $IsWindows) {
+        return ([System.Environment]::UserName -eq 'root')
+    }
+
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Resolve-PlatformName {
+    param([string]$Name)
+
+    if ($Name -ne 'Auto') {
+        return $Name
+    }
+    if ((Get-Variable -Name IsMacOS -Scope Global -ErrorAction SilentlyContinue) -and $IsMacOS) {
+        return 'macOS'
+    }
+    if ((Get-Variable -Name IsLinux -Scope Global -ErrorAction SilentlyContinue) -and $IsLinux) {
+        return 'Linux'
+    }
+    return 'Windows'
+}
+
+function Get-DefaultProfileRoot {
+    param([string]$PlatformName)
+
+    switch ($PlatformName) {
+        'Windows' { return (Join-Path $env:LOCALAPPDATA 'BraveSoftware\Brave-Browser\User Data') }
+        'macOS' { return (Join-Path $HOME 'Library/Application Support/BraveSoftware/Brave-Browser') }
+        'Linux' { return (Join-Path $HOME '.config/BraveSoftware/Brave-Browser') }
+        default { return '' }
+    }
+}
+
+function Get-RegistryPolicyPath {
+    param([string]$ScopeName)
+
+    if ($ScopeName -eq 'LocalMachine') {
+        return 'Registry::HKEY_LOCAL_MACHINE\Software\Policies\BraveSoftware\Brave'
+    }
+
+    return 'Registry::HKEY_CURRENT_USER\Software\Policies\BraveSoftware\Brave'
+}
+
+function Get-RegistryBasePath {
+    param([string]$ScopeName)
+
+    if ($ScopeName -eq 'LocalMachine') {
+        if (-not (Test-IsAdministrator)) {
+            throw 'LocalMachine scope needs an elevated PowerShell session. Use -Scope CurrentUser, or reopen PowerShell as administrator/root and run the command again.'
+        }
+    }
+
+    return (Get-RegistryPolicyPath -ScopeName $ScopeName)
+}
+
+function Get-PolicyTarget {
+    param(
+        [string]$PlatformName,
+        [string]$ScopeName,
+        [string]$OverridePath
+    )
+
+    switch ($PlatformName) {
+        'Windows' {
+            return [pscustomobject]@{ Platform = $PlatformName; Kind = 'Registry'; Path = (Get-RegistryBasePath -ScopeName $ScopeName) }
+        }
+        'Linux' {
+            $path = if ([string]::IsNullOrWhiteSpace($OverridePath)) { '/etc/brave/policies/managed/BraveDebloater.json' } else { $OverridePath }
+            return [pscustomobject]@{ Platform = $PlatformName; Kind = 'JsonFile'; Path = $path }
+        }
+        'macOS' {
+            if ($ScopeName -eq 'LocalMachine') {
+                $path = if ([string]::IsNullOrWhiteSpace($OverridePath)) { '/Library/Managed Preferences/com.brave.Browser.plist' } else { $OverridePath }
+                return [pscustomobject]@{ Platform = $PlatformName; Kind = 'MacOSPlist'; Path = $path }
+            }
+            return [pscustomobject]@{ Platform = $PlatformName; Kind = 'MacOSDefaults'; Path = 'com.brave.Browser' }
+        }
+        default {
+            return [pscustomobject]@{ Platform = $PlatformName; Kind = 'MobileMDM'; Path = 'MDM profile' }
+        }
+    }
+}
+
+function Get-RegistrySnapshot {
+    param(
+        [string]$BasePath,
+        [string[]]$PolicyNames
+    )
+
+    $snapshot = New-Object System.Collections.Generic.List[object]
+    $keyExists = Test-Path -LiteralPath $BasePath
+    $key = $null
+    if ($keyExists) {
+        $key = Get-Item -LiteralPath $BasePath
+    }
+
+    foreach ($policyName in $PolicyNames) {
+        $entry = [ordered]@{
+            name = $policyName
+            existed = $false
+            value = $null
+            kind = $null
+        }
+
+        if ($keyExists) {
+            try {
+                $value = $key.GetValue($policyName, $null)
+                if ($null -ne $value) {
+                    $entry.existed = $true
+                    $entry.value = $value
+                    $entry.kind = $key.GetValueKind($policyName).ToString()
+                }
+            }
+            catch {
+                $entry.existed = $false
+            }
+        }
+
+        [void]$snapshot.Add([pscustomobject]$entry)
+    }
+
+    return $snapshot.ToArray()
+}
+
+function Get-PolicyValue {
+    param(
+        [Parameter(Mandatory = $true)]$Target,
+        [Parameter(Mandatory = $true)][string]$Name
+    )
+
+    if ($Target.Kind -eq 'Registry') {
+        if (Test-Path -LiteralPath $Target.Path) {
+            $key = Get-Item -LiteralPath $Target.Path
+            $value = $key.GetValue($Name, $null)
+            if ($null -ne $value) {
+                return [pscustomobject]@{ Exists = $true; Value = $value; Kind = $key.GetValueKind($Name).ToString() }
+            }
+        }
+        return [pscustomobject]@{ Exists = $false; Value = $null; Kind = $null }
+    }
+
+    if ($Target.Kind -eq 'JsonFile') {
+        if (Test-Path -LiteralPath $Target.Path) {
+            $json = Get-Content -LiteralPath $Target.Path -Raw | ConvertFrom-Json
+            $property = $json.PSObject.Properties[$Name]
+            if ($null -ne $property) {
+                return [pscustomobject]@{ Exists = $true; Value = $property.Value; Kind = 'DWord' }
+            }
+        }
+        return [pscustomobject]@{ Exists = $false; Value = $null; Kind = $null }
+    }
+
+    if ($Target.Kind -eq 'MacOSDefaults' -or $Target.Kind -eq 'MacOSPlist') {
+        $arguments = if ($Target.Kind -eq 'MacOSDefaults') { @('read', $Target.Path, $Name) } else { @('read', ($Target.Path -replace '\.plist$', ''), $Name) }
+        $output = & /usr/bin/defaults @arguments 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            $text = $output -join "`n"
+            $number = 0
+            $value = if ([int]::TryParse($text, [ref]$number)) { $number } else { $text }
+            $kind = if ($value -is [int]) { 'DWord' } else { 'String' }
+            return [pscustomobject]@{ Exists = $true; Value = $value; Kind = $kind }
+        }
+    }
+
+    return [pscustomobject]@{ Exists = $false; Value = $null; Kind = $null }
+}
+
+function Get-PolicySnapshot {
+    param(
+        [Parameter(Mandatory = $true)]$Target,
+        [string[]]$PolicyNames
+    )
+
+    $snapshot = New-Object System.Collections.Generic.List[object]
+    foreach ($policyName in $PolicyNames) {
+        $value = Get-PolicyValue -Target $Target -Name $policyName
+        [void]$snapshot.Add([pscustomobject]@{
+                name = $policyName
+                existed = [bool]$value.Exists
+                value = $value.Value
+                kind = $value.Kind
+            })
+    }
+    return $snapshot.ToArray()
+}
+
+function Set-PolicyValue {
+    param(
+        [Parameter(Mandatory = $true)]$Target,
+        [string]$Name,
+        [Parameter(Mandatory = $true)]$Definition
+    )
+
+    if ($Target.Kind -eq 'Registry') {
+        Set-BravePolicy -BasePath $Target.Path -Name $Name -Definition $Definition
+        return
+    }
+
+    $value = if ($Definition.type -eq 'DWord') { [int]$Definition.value } else { [string]$Definition.value }
+    if ($Target.Kind -eq 'JsonFile') {
+        $json = [pscustomobject]@{}
+        if (Test-Path -LiteralPath $Target.Path) {
+            $json = Get-Content -LiteralPath $Target.Path -Raw | ConvertFrom-Json
+        }
+        if ($null -eq $json.PSObject.Properties[$Name]) {
+            $json | Add-Member -NotePropertyName $Name -NotePropertyValue $value
+        }
+        else {
+            $json.PSObject.Properties[$Name].Value = $value
+        }
+        Set-JsonFileContent -Path $Target.Path -Object $json
+        return
+    }
+
+    if ($Target.Kind -eq 'MacOSDefaults' -or $Target.Kind -eq 'MacOSPlist') {
+        $domain = if ($Target.Kind -eq 'MacOSDefaults') { $Target.Path } else { $Target.Path -replace '\.plist$', '' }
+        $typeFlag = if ($Definition.type -eq 'DWord') { '-int' } else { '-string' }
+        if ($Target.Kind -eq 'MacOSPlist') {
+            $directory = Split-Path -Parent $Target.Path
+            if (-not (Test-Path -LiteralPath $directory)) {
+                New-Item -ItemType Directory -Path $directory -Force | Out-Null
+            }
+        }
+        & /usr/bin/defaults write $domain $Name $typeFlag $value
+        if ($LASTEXITCODE -ne 0) {
+            throw "Could not write macOS policy '$Name' to $($Target.Path). Check file permissions, then rerun with -Apply."
+        }
+        return
+    }
+
+    throw "$($Target.Platform) policies are managed by MDM and cannot be written locally by this script. Use -ExportPolicyPath to create a payload for your device manager."
+}
+
+function Remove-PolicyValue {
+    param(
+        [Parameter(Mandatory = $true)]$Target,
+        [string]$Name
+    )
+
+    if ($Target.Kind -eq 'Registry') {
+        if (Test-Path -LiteralPath $Target.Path) {
+            Remove-ItemProperty -LiteralPath $Target.Path -Name $Name -ErrorAction SilentlyContinue
+        }
+        return
+    }
+    if ($Target.Kind -eq 'JsonFile') {
+        if (Test-Path -LiteralPath $Target.Path) {
+            $json = Get-Content -LiteralPath $Target.Path -Raw | ConvertFrom-Json
+            $json.PSObject.Properties.Remove($Name)
+            Set-JsonFileContent -Path $Target.Path -Object $json
+        }
+        return
+    }
+    if ($Target.Kind -eq 'MacOSDefaults' -or $Target.Kind -eq 'MacOSPlist') {
+        $domain = if ($Target.Kind -eq 'MacOSDefaults') { $Target.Path } else { $Target.Path -replace '\.plist$', '' }
+        & /usr/bin/defaults delete $domain $Name 2>$null
+    }
+}
+
+function Get-RegistryPolicyReport {
+    param([string]$ScopeName)
+
+    $path = Get-RegistryPolicyPath -ScopeName $ScopeName
+    $entries = New-Object System.Collections.Generic.List[object]
+    $keyExists = $false
+    $canRead = $true
+    $errorMessage = ''
+
+    try {
+        $keyExists = Test-Path -LiteralPath $path
+        if ($keyExists) {
+            $key = Get-Item -LiteralPath $path
+            foreach ($name in $key.GetValueNames()) {
+                if ([string]::IsNullOrWhiteSpace($name)) {
+                    continue
+                }
+
+                [void]$entries.Add([pscustomobject]@{
+                        Name = [string]$name
+                        Value = $key.GetValue($name, $null)
+                        Kind = $key.GetValueKind($name).ToString()
+                    })
+            }
+        }
+    }
+    catch {
+        $canRead = $false
+        $errorMessage = $_.Exception.Message
+        $entries.Clear()
+    }
+
+    return [pscustomobject]@{
+        Scope = $ScopeName
+        Path = $path
+        KeyExists = $keyExists
+        CanRead = $canRead
+        ErrorMessage = $errorMessage
+        Entries = $entries.ToArray()
+    }
+}
+
+function Get-PolicyReport {
+    param(
+        [Parameter(Mandatory = $true)]$Target,
+        [string]$ScopeName,
+        [string[]]$PolicyNames = @()
+    )
+
+    if ($Target.Kind -eq 'Registry') {
+        return Get-RegistryPolicyReport -ScopeName $ScopeName
+    }
+
+    $entries = New-Object System.Collections.Generic.List[object]
+    $keyExists = Test-Path -LiteralPath $Target.Path
+    $canRead = $true
+    $errorMessage = ''
+
+    try {
+        if ($Target.Kind -eq 'JsonFile' -and $keyExists) {
+            $json = Get-Content -LiteralPath $Target.Path -Raw | ConvertFrom-Json
+            foreach ($property in $json.PSObject.Properties) {
+                [void]$entries.Add([pscustomobject]@{ Name = $property.Name; Value = $property.Value; Kind = 'DWord' })
+            }
+        }
+        elseif ($Target.Kind -eq 'MacOSDefaults' -or $Target.Kind -eq 'MacOSPlist') {
+            foreach ($policyName in $PolicyNames) {
+                $value = Get-PolicyValue -Target $Target -Name $policyName
+                if ($value.Exists) {
+                    $keyExists = $true
+                    [void]$entries.Add([pscustomobject]@{ Name = $policyName; Value = $value.Value; Kind = $value.Kind })
+                }
+            }
+        }
+    }
+    catch {
+        $canRead = $false
+        $errorMessage = $_.Exception.Message
+        $entries.Clear()
+    }
+
+    return [pscustomobject]@{
+        Scope = $ScopeName
+        Path = $Target.Path
+        KeyExists = $keyExists
+        CanRead = $canRead
+        ErrorMessage = $errorMessage
+        Entries = $entries.ToArray()
+    }
+}
+
+function Get-PolicyEntryMap {
+    param([object[]]$Entries)
+
+    $map = @{}
+    foreach ($entry in @($Entries)) {
+        $map[[string]$entry.Name] = $entry
+    }
+    return $map
+}
+
+function Test-PolicyValueMatches {
+    param(
+        $ActualValue,
+        $ExpectedValue,
+        [string]$Type
+    )
+
+    try {
+        if ($Type -eq 'DWord' -or $Type -eq 'QWord') {
+            return ([int64]$ActualValue -eq [int64]$ExpectedValue)
+        }
+        if ($Type -eq 'String') {
+            return ([string]$ActualValue -eq [string]$ExpectedValue)
+        }
+    }
+    catch {
+        return $false
+    }
+
+    return $false
+}
+
+function Get-FeaturePolicyStatus {
+    param(
+        [Parameter(Mandatory = $true)]$Feature,
+        [hashtable]$PolicyEntries,
+        [hashtable]$PolicyDefinitions
+    )
+
+    $policies = @($Feature.policies)
+    if ($policies.Count -eq 0) {
+        return 'Profile-only'
+    }
+
+    $present = 0
+    $matching = 0
+    foreach ($policyName in $policies) {
+        if (-not $PolicyEntries.ContainsKey($policyName)) {
+            continue
+        }
+
+        $present++
+        $definition = $PolicyDefinitions[$policyName]
+        if (Test-PolicyValueMatches -ActualValue $PolicyEntries[$policyName].Value -ExpectedValue $definition.value -Type ([string]$definition.type)) {
+            $matching++
+        }
+    }
+
+    if ($present -eq 0) {
+        return 'Not applied'
+    }
+    if ($matching -eq $policies.Count) {
+        return 'Applied'
+    }
+    if ($matching -gt 0) {
+        return 'Partial'
+    }
+    return 'Different'
+}
+
+function Get-PolicyPayload {
+    param(
+        [string[]]$PolicyNames,
+        [hashtable]$PolicyDefinitions
+    )
+
+    $payload = [ordered]@{}
+    foreach ($policyName in $PolicyNames) {
+        $definition = $PolicyDefinitions[$policyName]
+        $payload[$policyName] = if ($definition.type -eq 'DWord') { [int]$definition.value } else { [string]$definition.value }
+    }
+    return $payload
+}
+
+function ConvertTo-PlistScalar {
+    param([Parameter(Mandatory = $true)]$Value)
+
+    if ($Value -is [bool]) {
+        if ($Value) { return '<true/>' }
+        return '<false/>'
+    }
+    if ($Value -is [int] -or $Value -is [long]) {
+        return "<integer>$Value</integer>"
+    }
+
+    $escaped = [System.Security.SecurityElement]::Escape([string]$Value)
+    return "<string>$escaped</string>"
+}
+
+function ConvertTo-PlistDocument {
+    param(
+        [Parameter(Mandatory = $true)]$Payload,
+        [string]$Domain = 'com.brave.Browser',
+        [switch]$MobileConfig
+    )
+
+    $lines = New-Object System.Collections.Generic.List[string]
+    [void]$lines.Add('<?xml version="1.0" encoding="UTF-8"?>')
+    [void]$lines.Add('<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">')
+    [void]$lines.Add('<plist version="1.0">')
+
+    if ($MobileConfig) {
+        $uuid = [guid]::NewGuid().ToString().ToUpperInvariant()
+        $payloadUuid = [guid]::NewGuid().ToString().ToUpperInvariant()
+        [void]$lines.Add('<dict>')
+        [void]$lines.Add('  <key>PayloadContent</key>')
+        [void]$lines.Add('  <array>')
+        [void]$lines.Add('    <dict>')
+        [void]$lines.Add('      <key>PayloadContent</key>')
+        [void]$lines.Add('      <dict>')
+        [void]$lines.Add("        <key>$Domain</key>")
+        [void]$lines.Add('        <dict>')
+        [void]$lines.Add('          <key>Forced</key>')
+        [void]$lines.Add('          <array>')
+        [void]$lines.Add('            <dict>')
+        [void]$lines.Add('              <key>mcx_preference_settings</key>')
+        [void]$lines.Add('              <dict>')
+        foreach ($entry in $Payload.GetEnumerator()) {
+            [void]$lines.Add("                <key>$($entry.Key)</key>")
+            [void]$lines.Add("                $(ConvertTo-PlistScalar -Value $entry.Value)")
+        }
+        [void]$lines.Add('              </dict>')
+        [void]$lines.Add('            </dict>')
+        [void]$lines.Add('          </array>')
+        [void]$lines.Add('        </dict>')
+        [void]$lines.Add('      </dict>')
+        [void]$lines.Add('      <key>PayloadIdentifier</key>')
+        [void]$lines.Add('      <string>org.bravedebloater.brave.managed</string>')
+        [void]$lines.Add('      <key>PayloadType</key>')
+        [void]$lines.Add('      <string>com.apple.ManagedClient.preferences</string>')
+        [void]$lines.Add('      <key>PayloadUUID</key>')
+        [void]$lines.Add("      <string>$payloadUuid</string>")
+        [void]$lines.Add('      <key>PayloadVersion</key>')
+        [void]$lines.Add('      <integer>1</integer>')
+        [void]$lines.Add('    </dict>')
+        [void]$lines.Add('  </array>')
+        [void]$lines.Add('  <key>PayloadDisplayName</key>')
+        [void]$lines.Add('  <string>BraveDebloater Brave policies</string>')
+        [void]$lines.Add('  <key>PayloadIdentifier</key>')
+        [void]$lines.Add('  <string>org.bravedebloater.brave</string>')
+        [void]$lines.Add('  <key>PayloadType</key>')
+        [void]$lines.Add('  <string>Configuration</string>')
+        [void]$lines.Add('  <key>PayloadUUID</key>')
+        [void]$lines.Add("  <string>$uuid</string>")
+        [void]$lines.Add('  <key>PayloadVersion</key>')
+        [void]$lines.Add('  <integer>1</integer>')
+        [void]$lines.Add('</dict>')
+    }
+    else {
+        [void]$lines.Add('<dict>')
+        foreach ($entry in $Payload.GetEnumerator()) {
+            [void]$lines.Add("  <key>$($entry.Key)</key>")
+            [void]$lines.Add("  $(ConvertTo-PlistScalar -Value $entry.Value)")
+        }
+        [void]$lines.Add('</dict>')
+    }
+
+    [void]$lines.Add('</plist>')
+    return ($lines.ToArray() -join "`n")
+}
+
+function Export-PolicyPayload {
+    param(
+        [Parameter(Mandatory = $true)]$Target,
+        [Parameter(Mandatory = $true)]$Payload,
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    $directory = Split-Path -Parent $Path
+    if (-not [string]::IsNullOrWhiteSpace($directory) -and -not (Test-Path -LiteralPath $directory)) {
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    }
+
+    if ($Target.Platform -eq 'Linux' -or $Target.Platform -eq 'Android' -or $Path.EndsWith('.json', [StringComparison]::OrdinalIgnoreCase)) {
+        Set-JsonFileContent -Path $Path -Object $Payload
+        return
+    }
+
+    $mobileConfig = $Target.Platform -eq 'iOS' -or $Path.EndsWith('.mobileconfig', [StringComparison]::OrdinalIgnoreCase)
+    ConvertTo-PlistDocument -Payload $Payload -MobileConfig:$mobileConfig | Set-Content -LiteralPath $Path -Encoding UTF8
+}
+
+function Set-BravePolicy {
+    param(
+        [string]$BasePath,
+        [string]$Name,
+        [Parameter(Mandatory = $true)]$Definition
+    )
+
+    if (-not (Test-Path -LiteralPath $BasePath)) {
+        New-Item -Path $BasePath -Force | Out-Null
+    }
+
+    $propertyType = switch ($Definition.type) {
+        'DWord' { 'DWord' }
+        'String' { 'String' }
+        default { throw "Unsupported registry type '$($Definition.type)' for policy '$Name'." }
+    }
+
+    $value = $Definition.value
+    if ($Definition.type -eq 'DWord') {
+        $value = [int]$value
+    }
+
+    New-ItemProperty -LiteralPath $BasePath -Name $Name -Value $value -PropertyType $propertyType -Force | Out-Null
+}

--- a/src/ProfilePreferences.ps1
+++ b/src/ProfilePreferences.ps1
@@ -1,0 +1,184 @@
+#requires -Version 5.1
+
+function Get-JsonPathResult {
+    param(
+        [Parameter(Mandatory = $true)]$Object,
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    $current = $Object
+    foreach ($part in ($Path -split '\.')) {
+        if ($null -eq $current -or $null -eq $current.PSObject.Properties[$part]) {
+            return [pscustomobject]@{ exists = $false; value = $null }
+        }
+        $current = $current.PSObject.Properties[$part].Value
+    }
+
+    return [pscustomobject]@{ exists = $true; value = $current }
+}
+
+function Set-JsonPathValue {
+    param(
+        [Parameter(Mandatory = $true)]$Object,
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)]$Value,
+        [bool]$CreateMissing = $false
+    )
+
+    $parts = $Path -split '\.'
+    $current = $Object
+
+    for ($i = 0; $i -lt ($parts.Count - 1); $i++) {
+        $part = $parts[$i]
+        if ($null -eq $current.PSObject.Properties[$part]) {
+            if (-not $CreateMissing) {
+                return $false
+            }
+            $child = [pscustomobject]@{}
+            $current | Add-Member -NotePropertyName $part -NotePropertyValue $child
+        }
+        $current = $current.PSObject.Properties[$part].Value
+    }
+
+    $leaf = $parts[-1]
+    if ($null -eq $current.PSObject.Properties[$leaf]) {
+        if (-not $CreateMissing) {
+            return $false
+        }
+        $current | Add-Member -NotePropertyName $leaf -NotePropertyValue $Value
+    }
+    else {
+        $current.PSObject.Properties[$leaf].Value = $Value
+    }
+
+    return $true
+}
+
+function Get-BraveProfilePreferenceFiles {
+    param([string]$Root)
+
+    $files = New-Object System.Collections.Generic.List[string]
+    if ([string]::IsNullOrWhiteSpace($Root)) {
+        return $files.ToArray()
+    }
+    if (-not (Test-Path -LiteralPath $Root)) {
+        return $files.ToArray()
+    }
+
+    Get-ChildItem -LiteralPath $Root -Directory -ErrorAction SilentlyContinue |
+        ForEach-Object {
+            $preferencesPath = Join-Path $_.FullName 'Preferences'
+            if (Test-Path -LiteralPath $preferencesPath) {
+                [void]$files.Add($preferencesPath)
+            }
+        }
+
+    return $files.ToArray()
+}
+
+function Invoke-ProfilePreferenceCleanup {
+    param(
+        [string]$Root,
+        [Parameter(Mandatory = $true)]$Manifest,
+        [string]$BackupPath,
+        [string[]]$SelectedFeatureIds = @(),
+        [switch]$UseFeatureFilter,
+        [switch]$DoApply
+    )
+
+    $files = @(Get-BraveProfilePreferenceFiles -Root $Root)
+    if ($files.Count -eq 0) {
+        Write-Warning "No Brave profile Preferences files were found under $Root. Profile preference cleanup was skipped."
+        return
+    }
+
+    if ($DoApply -and (Get-Process -Name brave -ErrorAction SilentlyContinue)) {
+        Write-Warning 'Brave is running, so profile preference cleanup was skipped. Close Brave, then rerun with -IncludeProfilePreferences -Apply.'
+        return
+    }
+
+    $profileBackups = New-Object System.Collections.Generic.List[object]
+    $patches = @($Manifest.profilePreferencePatches)
+    if ($UseFeatureFilter) {
+        $patches = @($patches | Where-Object {
+                $featureId = [string]$_.feature
+                [string]::IsNullOrWhiteSpace($featureId) -or ($SelectedFeatureIds -contains $featureId)
+            })
+    }
+
+    foreach ($file in $files) {
+        if (-not $DoApply) {
+            Write-DryRun "Would inspect profile file $file."
+        }
+
+        $json = $null
+        try {
+            $raw = Get-Content -LiteralPath $file -Raw
+            if ([string]::IsNullOrWhiteSpace($raw)) {
+                throw 'The file is empty.'
+            }
+            $json = $raw | ConvertFrom-Json
+        }
+        catch {
+            Write-Warning "Skipping invalid profile Preferences file: $file ($($_.Exception.Message)) No changes were made to this file."
+            continue
+        }
+
+        if ($json -isnot [System.Management.Automation.PSCustomObject]) {
+            Write-Warning "Skipping invalid profile Preferences file: $file (top-level value is not a JSON object). No changes were made to this file."
+            continue
+        }
+
+        $changed = $false
+
+        foreach ($patch in $patches) {
+            $path = [string]$patch.path
+            if ($path -match '(?i)shield') {
+                throw "Refusing profile preference patch that mentions Shields: $path. Profile cleanup will not change Brave Shields settings."
+            }
+
+            $current = Get-JsonPathResult -Object $json -Path $path
+            $createMissing = [bool]$patch.createMissing
+
+            if (-not $current.exists -and -not $createMissing) {
+                continue
+            }
+
+            if (-not $DoApply) {
+                if ($current.exists) {
+                    Write-DryRun "Would set $path in $file from '$($current.value)' to '$($patch.value)'."
+                }
+                else {
+                    Write-DryRun "Would create $path in $file with '$($patch.value)'."
+                }
+                continue
+            }
+
+            if (Set-JsonPathValue -Object $json -Path $path -Value $patch.value -CreateMissing:$createMissing) {
+                $changed = $true
+            }
+        }
+
+        if ($DoApply -and $changed) {
+            $profileBackupDirectory = Join-Path (Split-Path -Parent $BackupPath) 'profile-files'
+            if (-not (Test-Path -LiteralPath $profileBackupDirectory)) {
+                New-Item -ItemType Directory -Path $profileBackupDirectory -Force | Out-Null
+            }
+
+            $safeName = ($file -replace '[:\\\/ ]', '_')
+            $profileBackupPath = Join-Path $profileBackupDirectory "$safeName.bak"
+            Copy-Item -LiteralPath $file -Destination $profileBackupPath -Force
+            [void]$profileBackups.Add([pscustomobject]@{
+                originalPath = $file
+                backupPath = $profileBackupPath
+            })
+
+            Set-JsonFileContent -Path $file -Object $json -Depth 100
+            Write-Step "Updated profile preferences in $file."
+        }
+    }
+
+    if ($DoApply -and $profileBackups.Count -gt 0) {
+        Update-BackupProfileFiles -BackupPath $BackupPath -ProfileFiles $profileBackups.ToArray()
+    }
+}

--- a/src/Reports.ps1
+++ b/src/Reports.ps1
@@ -68,11 +68,16 @@ function Show-DoctorReport {
     Write-Step 'Use this report to see what Brave already has, then decide whether to run a preview or apply command.'
 
     $knownPolicyNames = @($PolicyDefinitions.Keys)
-    $currentUserTarget = Get-PolicyTarget -PlatformName $PlatformName -ScopeName 'CurrentUser' -OverridePath ''
-    $localMachineTarget = Get-PolicyTarget -PlatformName $PlatformName -ScopeName 'LocalMachine' -OverridePath $PolicyPath
+    $currentUserTarget = Get-PolicyTarget -PlatformName $PlatformName -ScopeName 'CurrentUser' -OverridePath '' -ReadOnly
+    $localMachineTarget = Get-PolicyTarget -PlatformName $PlatformName -ScopeName 'LocalMachine' -OverridePath $PolicyPath -ReadOnly
     $currentUserReport = Get-PolicyReport -Target $currentUserTarget -ScopeName 'CurrentUser' -PolicyNames $knownPolicyNames
     $localMachineReport = Get-PolicyReport -Target $localMachineTarget -ScopeName 'LocalMachine' -PolicyNames $knownPolicyNames
     $reports = @($currentUserReport, $localMachineReport)
+    if ($currentUserTarget.Kind -ne 'Registry' -and $currentUserTarget.Path -eq $localMachineTarget.Path) {
+        # Platforms like Linux expose a single machine-wide managed policy file, so both
+        # scopes resolve to the same path. List it once to avoid double-counting entries.
+        $reports = @($localMachineReport)
+    }
     $unreadableScopes = New-Object System.Collections.Generic.List[string]
 
     foreach ($report in $reports) {

--- a/src/Reports.ps1
+++ b/src/Reports.ps1
@@ -1,0 +1,200 @@
+#requires -Version 5.1
+
+function Show-PolicyList {
+    param(
+        [string[]]$PolicyNames,
+        [hashtable]$PolicyDefinitions
+    )
+
+    $rows = foreach ($name in $PolicyNames) {
+        $definition = $PolicyDefinitions[$name]
+        [pscustomobject]@{
+            Policy = $name
+            Value = $definition.value
+            Category = $definition.category
+            Reason = $definition.reason
+        }
+    }
+
+    $rows | Format-Table -AutoSize -Wrap
+}
+
+function Show-FeatureList {
+    param(
+        [object[]]$Features,
+        [string[]]$SelectedFeatureIds
+    )
+
+    $rows = foreach ($feature in @($Features)) {
+        [pscustomobject]@{
+            Feature = [string]$feature.id
+            Selected = ($SelectedFeatureIds -contains [string]$feature.id)
+            Label = [string]$feature.label
+            Reason = [string]$feature.reason
+        }
+    }
+
+    $rows | Format-Table -AutoSize -Wrap
+}
+
+function Show-ProfilePreferencePatchList {
+    param([object[]]$Patches)
+
+    $rows = foreach ($patch in @($Patches)) {
+        [pscustomobject]@{
+            Feature = [string]$patch.feature
+            PreferencePath = [string]$patch.path
+            Value = $patch.value
+            CreateMissing = [bool]$patch.createMissing
+            Reason = [string]$patch.reason
+        }
+    }
+
+    $rows | Format-Table -AutoSize -Wrap
+}
+
+function Show-DoctorReport {
+    param(
+        [Parameter(Mandatory = $true)]$Manifest,
+        [object[]]$Features,
+        [hashtable]$PolicyDefinitions,
+        [string]$ProfileRoot,
+        [string]$BackupDirectory,
+        [string]$PlatformName,
+        [string]$PolicyPath
+    )
+
+    Write-Step 'Doctor report (read-only). No policy, backup, or profile files will be changed.'
+    Write-Step 'Use this report to see what Brave already has, then decide whether to run a preview or apply command.'
+
+    $knownPolicyNames = @($PolicyDefinitions.Keys)
+    $currentUserTarget = Get-PolicyTarget -PlatformName $PlatformName -ScopeName 'CurrentUser' -OverridePath ''
+    $localMachineTarget = Get-PolicyTarget -PlatformName $PlatformName -ScopeName 'LocalMachine' -OverridePath $PolicyPath
+    $currentUserReport = Get-PolicyReport -Target $currentUserTarget -ScopeName 'CurrentUser' -PolicyNames $knownPolicyNames
+    $localMachineReport = Get-PolicyReport -Target $localMachineTarget -ScopeName 'LocalMachine' -PolicyNames $knownPolicyNames
+    $reports = @($currentUserReport, $localMachineReport)
+    $unreadableScopes = New-Object System.Collections.Generic.List[string]
+
+    foreach ($report in $reports) {
+        if (-not $report.CanRead) {
+            [void]$unreadableScopes.Add([string]$report.Scope)
+            Write-Step "$($report.Scope) policies: could not be read ($($report.ErrorMessage))"
+            continue
+        }
+
+        if ($report.Entries.Count -gt 0) {
+            Write-Step "$($report.Scope) policies: found $($report.Entries.Count) value(s)."
+        }
+        elseif ($report.KeyExists) {
+            Write-Step "$($report.Scope) policies: the policy location exists, but it has no values."
+        }
+        else {
+            Write-Step "$($report.Scope) policies: none detected."
+        }
+    }
+
+    if (-not $localMachineReport.CanRead) {
+        Write-Step 'Machine-wide policies: unknown because LocalMachine policies could not be read.'
+    }
+    elseif ($localMachineReport.Entries.Count -gt 0) {
+        Write-Step 'Machine-wide policies: detected. Brave may show managed settings for every user on this device.'
+    }
+    else {
+        Write-Step 'Machine-wide policies: none detected.'
+    }
+
+    $allPolicyNames = @($reports | ForEach-Object { @($_.Entries) } | ForEach-Object { [string]$_.Name })
+    $safetyFindings = @(Get-PolicySafetyFinding -PolicyNames $allPolicyNames -Manifest $Manifest)
+    if ($unreadableScopes.Count -gt 0) {
+        Write-Warning "Safety check incomplete: $($unreadableScopes.ToArray() -join ', ') policies could not be read."
+    }
+
+    if ($safetyFindings.Count -eq 0 -and $unreadableScopes.Count -eq 0) {
+        Write-Step 'Safety: no protected Brave policy names were detected.'
+    }
+    elseif ($safetyFindings.Count -gt 0) {
+        foreach ($finding in $safetyFindings) {
+            Write-Warning "Safety issue: $finding"
+        }
+    }
+
+    $braveProcesses = @(Get-Process -Name brave -ErrorAction SilentlyContinue)
+    if ($braveProcesses.Count -gt 0) {
+        Write-Step "Brave process: running ($($braveProcesses.Count) process(es)). Profile preference cleanup would be skipped until Brave is closed."
+    }
+    else {
+        Write-Step 'Brave process: not running.'
+    }
+
+    $profileFiles = @(Get-BraveProfilePreferenceFiles -Root $ProfileRoot)
+    if (-not [string]::IsNullOrWhiteSpace($ProfileRoot) -and (Test-Path -LiteralPath $ProfileRoot)) {
+        Write-Step "Profile root: found $($profileFiles.Count) Preferences file(s) under $ProfileRoot"
+    }
+    else {
+        Write-Step "Profile root: missing - $ProfileRoot"
+    }
+
+    $backupSummary = Get-BackupSummary -Directory $BackupDirectory
+    Write-Step "Backups: $($backupSummary.Count) found in $($backupSummary.Directory)"
+    if (-not [string]::IsNullOrWhiteSpace($backupSummary.Latest)) {
+        Write-Step "Latest backup: $($backupSummary.Latest)"
+    }
+
+    $currentUserPolicies = Get-PolicyEntryMap -Entries $currentUserReport.Entries
+    $localMachinePolicies = Get-PolicyEntryMap -Entries $localMachineReport.Entries
+
+    Write-Step 'Policy scopes:'
+    $scopeRows = foreach ($report in $reports) {
+        $status = 'Missing'
+        if (-not $report.CanRead) {
+            $status = 'Read failed'
+        }
+        elseif ($report.Entries.Count -gt 0) {
+            $status = 'Found'
+        }
+        elseif ($report.KeyExists) {
+            $status = 'Empty'
+        }
+
+        [pscustomobject]@{
+            Scope = $report.Scope
+            Status = $status
+            Values = $report.Entries.Count
+            Path = $report.Path
+        }
+    }
+    $scopeRows | Format-Table -AutoSize -Wrap
+
+    Write-Step 'Feature status:'
+    $featureRows = foreach ($feature in @($Features)) {
+        [pscustomobject]@{
+            Feature = [string]$feature.id
+            CurrentUser = if (-not $currentUserReport.CanRead) { 'Read failed' } else { Get-FeaturePolicyStatus -Feature $feature -PolicyEntries $currentUserPolicies -PolicyDefinitions $PolicyDefinitions }
+            LocalMachine = if (-not $localMachineReport.CanRead) { 'Read failed' } else { Get-FeaturePolicyStatus -Feature $feature -PolicyEntries $localMachinePolicies -PolicyDefinitions $PolicyDefinitions }
+            Label = [string]$feature.label
+        }
+    }
+    $featureRows | Format-Table -AutoSize -Wrap
+
+    $unknownRows = New-Object System.Collections.Generic.List[object]
+    foreach ($report in $reports) {
+        foreach ($entry in @($report.Entries)) {
+            if (-not $PolicyDefinitions.ContainsKey([string]$entry.Name)) {
+                [void]$unknownRows.Add([pscustomobject]@{
+                        Scope = $report.Scope
+                        Policy = [string]$entry.Name
+                        Value = $entry.Value
+                        Kind = [string]$entry.Kind
+                    })
+            }
+        }
+    }
+
+    if ($unknownRows.Count -gt 0) {
+        Write-Step 'Unknown Brave policies: detected. These may have been set by Brave, another tool, or an organization.'
+        $unknownRows.ToArray() | Format-Table -AutoSize -Wrap
+    }
+    else {
+        Write-Step 'Unknown Brave policies: none detected.'
+    }
+}


### PR DESCRIPTION
## Summary

- Adds PowerShell-based Brave policy writes for Windows, macOS, and Linux.
- Adds Android and iOS/iPadOS MDM export paths instead of local mobile-device writes.
- Splits the entrypoint into `src/*.ps1` modules for policy manifests, platform policy writes, backups, profile preferences, and reports.
- Updates the policy manifest from Brave policy template version `148.1.91.121` to `150.1.93.96`, with source notes in `docs/debloatable-validation.md`.
- Adds CI coverage for PowerShell 7 on Windows, macOS, and Linux, Windows PowerShell 5.1, and Brave policy-template validation.

## Requested By

@xsyetopz asked GPT-5.5 via Codex CLI to open this PR. Codex CLI was only used to open the PR; any follow-up comments will come from @xsyetopz .

## Validation

- `pwsh -NoProfile -File scripts/Test-PolicyManifest.ps1`
- `pwsh -NoProfile -File scripts/Test-Behavior.ps1`
- `pwsh -NoProfile -File scripts/Test-LatestPolicyTemplates.ps1 -TemplateZipPath /tmp/brave-policy-templates.zip`
- `./Invoke-BraveDebloat.ps1 -OnlyFeature Rewards`
- Android export smoke check wrote `"BraveRewardsDisabled": true`.

## Platform Check

The user confirmed the policy flow works outside Windows. The macOS check used Brave `brave://policy`; the screenshot supplied by the user shows policies loaded from `Platform` / `Current user` with status `OK`, including boolean values such as `BraveRewardsDisabled = true`.
