### PR TITLE
Remove leftover obsolete Brave policies from apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Stop applying Brave's obsolete `PrivacySandboxPromptEnabled` policy, and remove leftover copies of that name plus `PromotionalTabsEnabled` and `IPFSEnabled` from the selected policy target on apply so `brave://policy` no longer flags them.
+- Dry-run and `-WhatIf` still preview selected policy writes when an existing Linux policy JSON file is unreadable or malformed; leftover obsolete cleanup is skipped with a warning until the file can be read.
 - Fixed profile `Preferences`, backup, and policy JSON being read as ANSI on Windows PowerShell 5.1, which mangled non-ASCII text such as profile names on write. All JSON is now read as UTF-8 and written without a byte order mark.
 - Fixed the Brave process check missing the macOS `Brave Browser` process name, which allowed profile preference cleanup while Brave was open.
 - Restores that include profile `Preferences` files now stop before writing anything if Brave is running, and Windows registry or macOS backups refuse to apply on another platform.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Stop applying Brave's obsolete `PrivacySandboxPromptEnabled` policy, and remove leftover copies of that name plus `PromotionalTabsEnabled` and `IPFSEnabled` from the selected policy target on apply so `brave://policy` no longer flags them.
-- Dry-run and `-WhatIf` still preview selected policy writes when an existing Linux policy JSON file is unreadable or malformed; leftover obsolete cleanup is skipped with a warning until the file can be read.
+- Dry-run and `-WhatIf` still preview selected policy writes when an existing Linux policy JSON file is unreadable or malformed; leftover obsolete cleanup is skipped with a warning. `-Apply` still stops before writing a backup if that file cannot be read.
 - Fixed profile `Preferences`, backup, and policy JSON being read as ANSI on Windows PowerShell 5.1, which mangled non-ASCII text such as profile names on write. All JSON is now read as UTF-8 and written without a byte order mark.
 - Fixed the Brave process check missing the macOS `Brave Browser` process name, which allowed profile preference cleanup while Brave was open.
 - Restores that include profile `Preferences` files now stop before writing anything if Brave is running, and Windows registry or macOS backups refuse to apply on another platform.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Stop applying Brave's obsolete `PrivacySandboxPromptEnabled` policy, and remove leftover copies of that name plus `PromotionalTabsEnabled` and `IPFSEnabled` from the selected policy target on apply so `brave://policy` no longer flags them.
 - Fixed profile `Preferences`, backup, and policy JSON being read as ANSI on Windows PowerShell 5.1, which mangled non-ASCII text such as profile names on write. All JSON is now read as UTF-8 and written without a byte order mark.
 - Fixed the Brave process check missing the macOS `Brave Browser` process name, which allowed profile preference cleanup while Brave was open.
 - Restores that include profile `Preferences` files now stop before writing anything if Brave is running, and Windows registry or macOS backups refuse to apply on another platform.

--- a/Invoke-BraveDebloat.ps1
+++ b/Invoke-BraveDebloat.ps1
@@ -277,9 +277,24 @@ if ($IncludeProfilePreferences -and $applyChanges -and $NoBackup) {
     throw 'Profile preference cleanup requires backups. Remove -NoBackup, or omit -IncludeProfilePreferences and apply policy-only changes.'
 }
 
+$obsoletePolicyNames = New-Object System.Collections.Generic.List[string]
+if ($policyTarget.Kind -ne 'MobileMDM') {
+    foreach ($name in @(Get-PresentPolicyNames -Target $policyTarget -PolicyNames @(Get-DeprecatedPolicyNames -Manifest $manifest))) {
+        [void]$obsoletePolicyNames.Add($name)
+    }
+}
+
+$backupPolicyNames = New-Object System.Collections.Generic.List[string]
+foreach ($name in $policyNames) {
+    [void]$backupPolicyNames.Add($name)
+}
+foreach ($name in $obsoletePolicyNames) {
+    Add-StringIfMissing -List $backupPolicyNames -Value $name
+}
+
 $backupPath = $null
 if ($applyChanges -and -not $NoBackup) {
-    $backupPath = New-Backup -Directory $BackupDirectory -ScopeName $Scope -Target $policyTarget -PolicyNames $policyNames.ToArray() -ProfileRoot $ProfileRoot -Manifest $manifest
+    $backupPath = New-Backup -Directory $BackupDirectory -ScopeName $Scope -Target $policyTarget -PolicyNames $backupPolicyNames.ToArray() -ProfileRoot $ProfileRoot -Manifest $manifest
     Write-Step "Backup written to $backupPath"
 }
 
@@ -298,18 +313,34 @@ foreach ($policyName in $policyNames) {
     }
 }
 
+$removedObsoleteCount = 0
+foreach ($policyName in $obsoletePolicyNames) {
+    if (-not $applyChanges) {
+        Write-DryRun "Would remove $policyName because Brave marks it obsolete."
+        continue
+    }
+
+    if ($PSCmdlet.ShouldProcess($policyTarget.Path, "Remove obsolete policy $policyName")) {
+        Remove-PolicyValue -Target $policyTarget -Name $policyName
+        $removedObsoleteCount++
+        Write-Step "Removed obsolete $policyName."
+    }
+}
+
 if ($IncludeProfilePreferences) {
     Invoke-ProfilePreferenceCleanup -Root $ProfileRoot -Manifest $manifest -BackupPath $backupPath -SelectedFeatureIds $selectedFeatureIds -UseFeatureFilter:$customFeatureRequested -DoApply:$applyChanges
 }
 
+$obsoletePlanSummary = if ($obsoletePolicyNames.Count -gt 0) { ", $($obsoletePolicyNames.Count) obsolete leftover(s) to remove" } else { '' }
+$obsoleteDoneSummary = if ($removedObsoleteCount -gt 0) { " Removed $removedObsoleteCount obsolete leftover(s)." } else { '' }
 if (-not $applyChanges) {
     if ($isWhatIf) {
-        Write-Step "WhatIf complete. $($policyNames.Count) policy value(s) planned, no changes were made. Rerun with -Apply without -WhatIf when you are ready."
+        Write-Step "WhatIf complete. $($policyNames.Count) policy value(s) planned$obsoletePlanSummary, no changes were made. Rerun with -Apply without -WhatIf when you are ready."
     }
     else {
-        Write-Step "Dry-run complete. $($policyNames.Count) policy value(s) planned, no changes were made. Rerun with -Apply when you are ready."
+        Write-Step "Dry-run complete. $($policyNames.Count) policy value(s) planned$obsoletePlanSummary, no changes were made. Rerun with -Apply when you are ready."
     }
 }
 else {
-    Write-Step "Done. Set $appliedPolicyCount of $($policyNames.Count) policy value(s). Restart Brave, then open brave://policy to check the applied policies."
+    Write-Step "Done. Set $appliedPolicyCount of $($policyNames.Count) policy value(s).$obsoleteDoneSummary Restart Brave, then open brave://policy to check the applied policies."
 }

--- a/Invoke-BraveDebloat.ps1
+++ b/Invoke-BraveDebloat.ps1
@@ -279,8 +279,16 @@ if ($IncludeProfilePreferences -and $applyChanges -and $NoBackup) {
 
 $obsoletePolicyNames = New-Object System.Collections.Generic.List[string]
 if ($policyTarget.Kind -ne 'MobileMDM') {
-    foreach ($name in @(Get-PresentPolicyNames -Target $policyTarget -PolicyNames @(Get-DeprecatedPolicyNames -Manifest $manifest))) {
-        [void]$obsoletePolicyNames.Add($name)
+    try {
+        foreach ($name in @(Get-PresentPolicyNames -Target $policyTarget -PolicyNames @(Get-DeprecatedPolicyNames -Manifest $manifest))) {
+            [void]$obsoletePolicyNames.Add($name)
+        }
+    }
+    catch {
+        if ($applyChanges) {
+            throw
+        }
+        Write-Warning "Could not read existing policies at '$($policyTarget.Path)', so leftover obsolete policies were not checked: $($_.Exception.Message)"
     }
 }
 

--- a/Invoke-BraveDebloat.ps1
+++ b/Invoke-BraveDebloat.ps1
@@ -302,6 +302,9 @@ foreach ($name in $obsoletePolicyNames) {
 
 $backupPath = $null
 if ($applyChanges -and -not $NoBackup) {
+    if ($policyTarget.Kind -eq 'JsonFile' -and (Test-Path -LiteralPath $policyTarget.Path)) {
+        Get-ManagedPolicyJson -Path $policyTarget.Path | Out-Null
+    }
     $backupPath = New-Backup -Directory $BackupDirectory -ScopeName $Scope -Target $policyTarget -PolicyNames $backupPolicyNames.ToArray() -ProfileRoot $ProfileRoot -Manifest $manifest
     Write-Step "Backup written to $backupPath"
 }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ PowerShell is the cross-platform runtime. The files it writes are native to each
 
 Brave-specific surfaces:
 
-- Rewards, Wallet, VPN, Leo AI Chat, News, Talk, Playlist, Email Aliases, IPFS, Speedreader, and Wayback prompts
+- Rewards, Wallet, VPN, Leo AI Chat, News, Talk, Playlist, Email Aliases, Speedreader, and Wayback prompts
 
 Telemetry and suggestions:
 
@@ -214,7 +214,7 @@ Use `-IncludeFeature` and `-ExcludeFeature` for repeatable commands.
 
 Use `-OnlyFeature` when you want exactly the named cleanups without starting from a preset.
 
-Feature names are shown by `-ListFeatures`. Examples include `Rewards`, `Wallet`, `VPN`, `LeoAI`, `News`, `Talk`, `EmailAliases`, `IPFS`, `Autofill`, `Translate`, and `GoogleSearchSidePanel`.
+Feature names are shown by `-ListFeatures`. Examples include `Rewards`, `Wallet`, `VPN`, `LeoAI`, `News`, `Talk`, `EmailAliases`, `Autofill`, `Translate`, and `GoogleSearchSidePanel`.
 
 When `-IncludeProfilePreferences` is combined with custom feature choices, profile preference patches are filtered to the selected features.
 

--- a/config/policies.json
+++ b/config/policies.json
@@ -21,7 +21,8 @@
   },
   "deprecatedPolicies": [
     "PrivacySandboxPromptEnabled",
-    "PromotionalTabsEnabled"
+    "PromotionalTabsEnabled",
+    "IPFSEnabled"
   ],
   "safety": {
     "blockedPolicyNames": [
@@ -59,7 +60,6 @@
       "BraveTalkDisabled",
       "BravePlaylistEnabled",
       "EmailAliasesEnabled",
-      "IPFSEnabled",
       "BraveSpeedreaderEnabled",
       "BraveWaybackMachineEnabled",
       "BraveP3AEnabled",
@@ -166,14 +166,6 @@
         "EmailAliasesEnabled"
       ],
       "reason": "Disable Brave Email Aliases entry points."
-    },
-    {
-      "id": "IPFS",
-      "label": "IPFS",
-      "policies": [
-        "IPFSEnabled"
-      ],
-      "reason": "Disable IPFS integration."
     },
     {
       "id": "Speedreader",
@@ -427,12 +419,6 @@
       "value": 0,
       "category": "Brave feature",
       "reason": "Disable Brave Email Aliases."
-    },
-    "IPFSEnabled": {
-      "type": "DWord",
-      "value": 0,
-      "category": "Brave feature",
-      "reason": "Disable IPFS integration."
     },
     "BraveSpeedreaderEnabled": {
       "type": "DWord",

--- a/docs/debloatable-validation.md
+++ b/docs/debloatable-validation.md
@@ -24,9 +24,8 @@ The manifest version in `config/policies.json` changed from `151.1.94.91` to `15
 These official-template policies were added because they match BraveDebloater's scope:
 
 - `EmailAliasesEnabled = 0`
-- `IPFSEnabled = 0`
 
-The manifest's `deprecatedPolicies` list records names that must stay out of active presets. The current template marks `PrivacySandboxPromptEnabled` and `PromotionalTabsEnabled` as deprecated. They are excluded from the manifest; `PromotionsEnabled = 0` is retained as the supported policy for promotional content and avoids the deprecated policy override.
+The manifest's `deprecatedPolicies` list records names that must stay out of active presets. The current template still lists `PrivacySandboxPromptEnabled`, `PromotionalTabsEnabled`, and `IPFSEnabled`, but places them under the `DeprecatedPolicies` category. They stay out of the active manifest; `PromotionsEnabled = 0` is retained as the supported policy for promotional content. Apply and dry-run remove leftover copies of those names from the selected Brave policy target so older installs do not keep showing them as obsolete in `brave://policy`.
 
 These official-template policies were checked and left out:
 
@@ -58,7 +57,8 @@ iOS/iPadOS export validation now reads that allow-list from the manifest instead
 It checks that:
 
 - the manifest version matches the zip `VERSION`;
-- every manifest policy exists in `windows/admx/brave.admx`;
+- every manifest policy exists in `windows/admx/brave.admx` and is not under `DeprecatedPolicies`;
+- every `deprecatedPolicies` name is absent from the ADMX template, or still present only under `DeprecatedPolicies` / `deprecated="true"`;
 - every iOS allow-listed policy is defined in the manifest.
 
 `scripts/Test-Behavior.ps1` also validates target-user registry safety. It checks that `-UserSid` builds only the exact Brave policy path under `HKEY_USERS`, rejects path-like SID input and non-Windows or machine-scope combinations, requires elevation for apply target construction, and requires the same explicit SID to preview a restore.

--- a/scripts/Test-Behavior.ps1
+++ b/scripts/Test-Behavior.ps1
@@ -496,6 +496,24 @@ try {
     if ($malformedAfterWhatIf -ne $malformedPolicyContent) {
         throw 'WhatIf modified a malformed Linux policy JSON file.'
     }
+    $malformedApplyBackupDirectory = Join-Path $tempRoot 'MalformedApplyBackups'
+    $malformedApplyFailed = $false
+    try {
+        & $scriptPath -Platform Linux -PolicyPath $malformedPolicyPath -OnlyFeature Rewards -Apply -BackupDirectory $malformedApplyBackupDirectory *>&1 | Out-Null
+    }
+    catch {
+        $malformedApplyFailed = $true
+    }
+    if (-not $malformedApplyFailed) {
+        throw 'Apply did not fail on malformed Linux policy JSON.'
+    }
+    if ((Test-Path -LiteralPath $malformedApplyBackupDirectory) -and (@(Get-ChildItem -LiteralPath $malformedApplyBackupDirectory -Filter 'BraveDebloater-*.json').Count -gt 0)) {
+        throw 'Apply wrote a backup before failing on malformed Linux policy JSON.'
+    }
+    $malformedAfterApply = Get-Content -LiteralPath $malformedPolicyPath -Raw
+    if ($malformedAfterApply -ne $malformedPolicyContent) {
+        throw 'Apply modified a malformed Linux policy JSON file.'
+    }
 
     $customLinuxBackup = Join-Path $tempRoot 'custom-linux-backup.json'
     [ordered]@{

--- a/scripts/Test-Behavior.ps1
+++ b/scripts/Test-Behavior.ps1
@@ -93,6 +93,11 @@ try {
     Assert-TextDoesNotContain -Text $onlyOutput -Unexpected 'BraveVPNDisabled' -Context '-OnlyFeature output'
     Assert-TextDoesNotContain -Text $onlyOutput -Unexpected 'BraveAIChatEnabled' -Context '-OnlyFeature output'
 
+    $extremeListOutput = (& $scriptPath -Preset Extreme -List *>&1 | Out-String)
+    Assert-TextDoesNotContain -Text $extremeListOutput -Unexpected 'PrivacySandboxPromptEnabled' -Context 'Extreme -List output'
+    Assert-TextDoesNotContain -Text $extremeListOutput -Unexpected 'PromotionalTabsEnabled' -Context 'Extreme -List output'
+    Assert-TextDoesNotContain -Text $extremeListOutput -Unexpected 'IPFSEnabled' -Context 'Extreme -List output'
+
     $onlyPatchOutput = (& $scriptPath -OnlyFeature Rewards -List -IncludeProfilePreferences *>&1 | Out-String)
     Assert-TextContains -Text $onlyPatchOutput -Expected 'brave.rewards.enabled' -Context '-OnlyFeature profile patch output'
     Assert-TextDoesNotContain -Text $onlyPatchOutput -Unexpected 'brave.new_tab_page.show_branded_background_image' -Context '-OnlyFeature profile patch output'
@@ -402,6 +407,75 @@ try {
     if ($linuxPolicyJson.BraveRewardsDisabled -isnot [bool] -or -not $linuxPolicyJson.BraveRewardsDisabled) {
         throw 'Linux policy apply did not write BraveRewardsDisabled = true.'
     }
+    Assert-TextDoesNotContain -Text $linuxApplyOutput -Unexpected 'obsolete' -Context 'Linux policy apply output'
+
+    $leftoverPolicyPath = Join-Path $tempRoot 'leftover-obsolete-policy.json'
+    $leftoverBackupDirectory = Join-Path $tempRoot 'LeftoverBackups'
+    [ordered]@{
+        PrivacySandboxPromptEnabled = $false
+        PromotionalTabsEnabled = $false
+    } | ConvertTo-Json | Set-Content -LiteralPath $leftoverPolicyPath -Encoding UTF8
+
+    $leftoverDoctorOutput = (& $scriptPath -Doctor -Platform Linux -PolicyPath $leftoverPolicyPath -ProfileRoot $missingProfileRoot -BackupDirectory $leftoverBackupDirectory *>&1 | Out-String)
+    Assert-TextContains -Text $leftoverDoctorOutput -Expected 'Obsolete leftover policies: detected. Rerun with -Apply to remove them.' -Context 'Doctor obsolete leftover output'
+    Assert-TextContains -Text $leftoverDoctorOutput -Expected 'PrivacySandboxPromptEnabled' -Context 'Doctor obsolete leftover output'
+    Assert-TextContains -Text $leftoverDoctorOutput -Expected 'PromotionalTabsEnabled' -Context 'Doctor obsolete leftover output'
+
+    $leftoverDryRunOutput = (& $scriptPath -Platform Linux -PolicyPath $leftoverPolicyPath -OnlyFeature Rewards -BackupDirectory $leftoverBackupDirectory *>&1 | Out-String)
+    Assert-TextContains -Text $leftoverDryRunOutput -Expected 'Would remove PrivacySandboxPromptEnabled because Brave marks it obsolete.' -Context 'obsolete leftover dry-run output'
+    Assert-TextContains -Text $leftoverDryRunOutput -Expected 'Would remove PromotionalTabsEnabled because Brave marks it obsolete.' -Context 'obsolete leftover dry-run output'
+    Assert-TextContains -Text $leftoverDryRunOutput -Expected '2 obsolete leftover(s) to remove' -Context 'obsolete leftover dry-run output'
+    $leftoverDryRunJson = Get-Content -LiteralPath $leftoverPolicyPath -Raw | ConvertFrom-Json
+    if ($null -eq $leftoverDryRunJson.PSObject.Properties['PrivacySandboxPromptEnabled'] -or $null -eq $leftoverDryRunJson.PSObject.Properties['PromotionalTabsEnabled']) {
+        throw 'Dry-run removed leftover obsolete policies.'
+    }
+
+    $leftoverApplyOutput = (& $scriptPath -Platform Linux -PolicyPath $leftoverPolicyPath -OnlyFeature Rewards -Apply -BackupDirectory $leftoverBackupDirectory *>&1 | Out-String)
+    Assert-TextContains -Text $leftoverApplyOutput -Expected 'Removed obsolete PrivacySandboxPromptEnabled.' -Context 'obsolete leftover apply output'
+    Assert-TextContains -Text $leftoverApplyOutput -Expected 'Removed obsolete PromotionalTabsEnabled.' -Context 'obsolete leftover apply output'
+    Assert-TextContains -Text $leftoverApplyOutput -Expected 'Removed 2 obsolete leftover(s).' -Context 'obsolete leftover apply output'
+    $leftoverApplyJson = Get-Content -LiteralPath $leftoverPolicyPath -Raw | ConvertFrom-Json
+    if ($null -ne $leftoverApplyJson.PSObject.Properties['PrivacySandboxPromptEnabled']) {
+        throw 'Linux policy apply left PrivacySandboxPromptEnabled in place.'
+    }
+    if ($null -ne $leftoverApplyJson.PSObject.Properties['PromotionalTabsEnabled']) {
+        throw 'Linux policy apply left PromotionalTabsEnabled in place.'
+    }
+    if ($leftoverApplyJson.BraveRewardsDisabled -isnot [bool] -or -not $leftoverApplyJson.BraveRewardsDisabled) {
+        throw 'Linux leftover apply did not write BraveRewardsDisabled = true.'
+    }
+    $leftoverBackups = @(Get-ChildItem -LiteralPath $leftoverBackupDirectory -Filter 'BraveDebloater-*.json')
+    if ($leftoverBackups.Count -ne 1) {
+        throw "Linux leftover apply did not create exactly one backup, found $($leftoverBackups.Count)."
+    }
+    $leftoverBackup = Get-Content -LiteralPath $leftoverBackups[0].FullName -Raw | ConvertFrom-Json
+    $leftoverBackupNames = @($leftoverBackup.policies | ForEach-Object { [string]$_.name })
+    if ($leftoverBackupNames -notcontains 'PrivacySandboxPromptEnabled' -or $leftoverBackupNames -notcontains 'PromotionalTabsEnabled') {
+        throw 'Linux leftover backup did not snapshot the obsolete policies.'
+    }
+
+    $leftoverRestoreOutput = (& $scriptPath -UndoFromBackup $leftoverBackups[0].FullName -PolicyPath $leftoverPolicyPath *>&1 | Out-String)
+    Assert-TextContains -Text $leftoverRestoreOutput -Expected 'Would restore PrivacySandboxPromptEnabled' -Context 'obsolete leftover restore dry-run output'
+    Assert-TextContains -Text $leftoverRestoreOutput -Expected 'Would restore PromotionalTabsEnabled' -Context 'obsolete leftover restore dry-run output'
+
+    $oldDeprecatedBackup = Join-Path $tempRoot 'old-deprecated-backup.json'
+    [ordered]@{
+        schemaVersion = 1
+        platform = 'Linux'
+        policyKind = 'JsonFile'
+        registryPath = $leftoverPolicyPath
+        policies = @(
+            [ordered]@{
+                name = 'PrivacySandboxPromptEnabled'
+                existed = $true
+                value = 0
+                kind = 'DWord'
+            }
+        )
+        profileFiles = @()
+    } | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $oldDeprecatedBackup -Encoding UTF8
+    $oldDeprecatedRestoreOutput = (& $scriptPath -UndoFromBackup $oldDeprecatedBackup -PolicyPath $leftoverPolicyPath *>&1 | Out-String)
+    Assert-TextContains -Text $oldDeprecatedRestoreOutput -Expected 'Would restore PrivacySandboxPromptEnabled' -Context 'old deprecated backup restore dry-run output'
 
     $customLinuxBackup = Join-Path $tempRoot 'custom-linux-backup.json'
     [ordered]@{

--- a/scripts/Test-Behavior.ps1
+++ b/scripts/Test-Behavior.ps1
@@ -477,6 +477,26 @@ try {
     $oldDeprecatedRestoreOutput = (& $scriptPath -UndoFromBackup $oldDeprecatedBackup -PolicyPath $leftoverPolicyPath *>&1 | Out-String)
     Assert-TextContains -Text $oldDeprecatedRestoreOutput -Expected 'Would restore PrivacySandboxPromptEnabled' -Context 'old deprecated backup restore dry-run output'
 
+    $malformedPolicyPath = Join-Path $tempRoot 'malformed-linux-policy.json'
+    $malformedPolicyContent = '{ this is not valid json'
+    Set-Content -LiteralPath $malformedPolicyPath -Value $malformedPolicyContent -Encoding UTF8 -NoNewline
+    $malformedDryRunOutput = (& $scriptPath -Platform Linux -PolicyPath $malformedPolicyPath -OnlyFeature Rewards *>&1 | Out-String)
+    Assert-TextContains -Text $malformedDryRunOutput -Expected 'Would set BraveRewardsDisabled' -Context 'malformed Linux policy dry-run output'
+    Assert-TextContains -Text $malformedDryRunOutput -Expected 'leftover obsolete policies were not checked' -Context 'malformed Linux policy dry-run output'
+    Assert-TextContains -Text $malformedDryRunOutput -Expected 'Dry-run complete.' -Context 'malformed Linux policy dry-run output'
+    Assert-TextDoesNotContain -Text $malformedDryRunOutput -Unexpected 'Would remove PrivacySandboxPromptEnabled' -Context 'malformed Linux policy dry-run output'
+    $malformedAfterDryRun = Get-Content -LiteralPath $malformedPolicyPath -Raw
+    if ($malformedAfterDryRun -ne $malformedPolicyContent) {
+        throw 'Dry-run modified a malformed Linux policy JSON file.'
+    }
+    $malformedWhatIfOutput = (& $scriptPath -Platform Linux -PolicyPath $malformedPolicyPath -OnlyFeature Rewards -Apply -WhatIf *>&1 | Out-String)
+    Assert-TextContains -Text $malformedWhatIfOutput -Expected 'Would set BraveRewardsDisabled' -Context 'malformed Linux policy WhatIf output'
+    Assert-TextContains -Text $malformedWhatIfOutput -Expected 'WhatIf complete.' -Context 'malformed Linux policy WhatIf output'
+    $malformedAfterWhatIf = Get-Content -LiteralPath $malformedPolicyPath -Raw
+    if ($malformedAfterWhatIf -ne $malformedPolicyContent) {
+        throw 'WhatIf modified a malformed Linux policy JSON file.'
+    }
+
     $customLinuxBackup = Join-Path $tempRoot 'custom-linux-backup.json'
     [ordered]@{
         schemaVersion = 1

--- a/scripts/Test-LatestPolicyTemplates.ps1
+++ b/scripts/Test-LatestPolicyTemplates.ps1
@@ -60,9 +60,45 @@ try {
         Where-Object { $_ -notmatch '_recommended$' } |
         Sort-Object -Unique)
 
+    $deprecatedInTemplate = @{}
+    foreach ($policyMatch in [regex]::Matches($admx, '<policy\b[^>]*\bname="([^"]+)"[^>]*>\s*<parentCategory\s+ref="DeprecatedPolicies"\s*/>')) {
+        $templatePolicyName = $policyMatch.Groups[1].Value
+        if ($templatePolicyName -match '_recommended$') {
+            continue
+        }
+        $deprecatedInTemplate[$templatePolicyName] = $true
+    }
+
+    foreach ($tagMatch in [regex]::Matches($admx, '<policy\b[^>]*>')) {
+        $tag = $tagMatch.Value
+        $nameMatch = [regex]::Match($tag, '\bname="([^"]+)"')
+        if (-not $nameMatch.Success) {
+            continue
+        }
+
+        $templatePolicyName = $nameMatch.Groups[1].Value
+        if ($templatePolicyName -match '_recommended$' -or $tag -notmatch '\bdeprecated="true"') {
+            continue
+        }
+        $deprecatedInTemplate[$templatePolicyName] = $true
+    }
+
     foreach ($policyName in @($manifest.policies.PSObject.Properties.Name)) {
         if ($templatePolicies -notcontains $policyName) {
             throw "Manifest policy '$policyName' is not present in the official Brave ADMX template."
+        }
+        if ($deprecatedInTemplate.ContainsKey($policyName)) {
+            throw "Manifest policy '$policyName' is marked deprecated in the official Brave ADMX template."
+        }
+    }
+
+    $deprecatedPolicyNames = @()
+    if ($null -ne $manifest.PSObject.Properties['deprecatedPolicies']) {
+        $deprecatedPolicyNames = @($manifest.deprecatedPolicies)
+    }
+    foreach ($policyName in $deprecatedPolicyNames) {
+        if ($templatePolicies -contains $policyName -and -not $deprecatedInTemplate.ContainsKey($policyName)) {
+            throw "Manifest deprecatedPolicies entry '$policyName' is still present in the official Brave ADMX template without a DeprecatedPolicies category."
         }
     }
 

--- a/src/Backup.ps1
+++ b/src/Backup.ps1
@@ -56,7 +56,8 @@ function Assert-BackupRegistryPath {
 function Assert-BackupPolicyList {
     param(
         [Parameter(Mandatory = $true)]$Backup,
-        [Parameter(Mandatory = $true)][hashtable]$PolicyDefinitions
+        [Parameter(Mandatory = $true)][hashtable]$PolicyDefinitions,
+        [string[]]$DeprecatedPolicyNames = @()
     )
 
     if ($null -eq $Backup.PSObject.Properties['policies']) {
@@ -70,7 +71,8 @@ function Assert-BackupPolicyList {
         if (-not ($existed -is [bool])) {
             throw "Backup policy '$name' has a non-boolean 'existed' value."
         }
-        if (-not $PolicyDefinitions.ContainsKey($name)) {
+        $isDeprecated = $DeprecatedPolicyNames -contains $name
+        if (-not $PolicyDefinitions.ContainsKey($name) -and -not $isDeprecated) {
             throw "Backup policy '$name' is not managed by this manifest."
         }
 
@@ -79,7 +81,7 @@ function Assert-BackupPolicyList {
             if (@('DWord', 'String') -notcontains $kind) {
                 throw "Backup policy '$name' has unsupported registry kind '$kind'."
             }
-            if ($kind -ne [string]$PolicyDefinitions[$name].type) {
+            if (-not $isDeprecated -and $kind -ne [string]$PolicyDefinitions[$name].type) {
                 throw "Backup policy '$name' registry kind '$kind' does not match the manifest type '$($PolicyDefinitions[$name].type)'."
             }
 
@@ -144,7 +146,7 @@ function Assert-BackupObject {
     Assert-BackupRegistryPath -RegistryPath $registryPath -AllowedPolicyPath $AllowedPolicyPath -AllowedUserPolicyPath $AllowedUserPolicyPath -DoApply:$DoApply
 
     $policyDefinitions = Get-ManifestMap -Object $Manifest.policies
-    Assert-BackupPolicyList -Backup $Backup -PolicyDefinitions $policyDefinitions
+    Assert-BackupPolicyList -Backup $Backup -PolicyDefinitions $policyDefinitions -DeprecatedPolicyNames @(Get-DeprecatedPolicyNames -Manifest $Manifest)
 
     $profileFiles = @()
     if ($null -ne $Backup.PSObject.Properties['profileFiles']) {

--- a/src/Manifest.ps1
+++ b/src/Manifest.ps1
@@ -9,6 +9,24 @@ function Get-Manifest {
     return (Get-JsonFileContent -Path $manifestPath)
 }
 
+function Get-DeprecatedPolicyNames {
+    param([Parameter(Mandatory = $true)]$Manifest)
+
+    $names = New-Object System.Collections.Generic.List[string]
+    if ($null -eq $Manifest.PSObject.Properties['deprecatedPolicies']) {
+        return $names.ToArray()
+    }
+
+    foreach ($name in @($Manifest.deprecatedPolicies)) {
+        $text = [string]$name
+        if (-not [string]::IsNullOrWhiteSpace($text)) {
+            Add-StringIfMissing -List $names -Value $text
+        }
+    }
+
+    return $names.ToArray()
+}
+
 function Resolve-PresetPolicies {
     param(
         [Parameter(Mandatory = $true)][string]$Name,

--- a/src/PlatformPolicy.ps1
+++ b/src/PlatformPolicy.ps1
@@ -261,9 +261,18 @@ function Get-PolicyValue {
     }
 
     if ($Target.Kind -eq 'MacOSDefaults' -or $Target.Kind -eq 'MacOSPlist') {
+        if (-not (Test-Path -LiteralPath '/usr/bin/defaults')) {
+            return [pscustomobject]@{ Exists = $false; Value = $null; Kind = $null; ReadError = $false }
+        }
+
         $arguments = if ($Target.Kind -eq 'MacOSDefaults') { @('read', $Target.Path, $Name) } else { @('read', ($Target.Path -replace '\.plist$', ''), $Name) }
-        $output = & /usr/bin/defaults @arguments 2>$null
-        $readSucceeded = $LASTEXITCODE -eq 0
+        try {
+            $output = & /usr/bin/defaults @arguments 2>$null
+            $readSucceeded = $LASTEXITCODE -eq 0
+        }
+        catch {
+            return [pscustomobject]@{ Exists = $false; Value = $null; Kind = $null; ReadError = $true }
+        }
         # `defaults read` exits non-zero when the key is absent (the common case during a scan).
         # Clear LASTEXITCODE so a missing key does not leak a failure exit code to the script.
         $global:LASTEXITCODE = 0
@@ -277,6 +286,27 @@ function Get-PolicyValue {
     }
 
     return [pscustomobject]@{ Exists = $false; Value = $null; Kind = $null; ReadError = $false }
+}
+
+function Get-PresentPolicyNames {
+    param(
+        [Parameter(Mandatory = $true)]$Target,
+        [string[]]$PolicyNames
+    )
+
+    $present = New-Object System.Collections.Generic.List[string]
+    foreach ($policyName in @($PolicyNames)) {
+        if ([string]::IsNullOrWhiteSpace([string]$policyName)) {
+            continue
+        }
+
+        $value = Get-PolicyValue -Target $Target -Name $policyName
+        if ($value.Exists -and -not $value.ReadError) {
+            [void]$present.Add($policyName)
+        }
+    }
+
+    return $present.ToArray()
 }
 
 function Get-PolicySnapshot {

--- a/src/PlatformPolicy.ps1
+++ b/src/PlatformPolicy.ps1
@@ -328,7 +328,7 @@ function Get-PresentPolicyNames {
 
     if ($hadReadError) {
         $detail = if ([string]::IsNullOrWhiteSpace($readErrorMessage)) { '' } else { ": $readErrorMessage" }
-        Write-Warning "Could not read existing policies at '$($Target.Path)', so leftover obsolete policies were not checked$detail."
+        throw "Could not read existing policies at '$($Target.Path)'$detail."
     }
 
     return $present.ToArray()

--- a/src/PlatformPolicy.ps1
+++ b/src/PlatformPolicy.ps1
@@ -251,10 +251,18 @@ function Get-PolicyValue {
 
     if ($Target.Kind -eq 'JsonFile') {
         if (Test-Path -LiteralPath $Target.Path) {
-            $json = Get-ManagedPolicyJson -Path $Target.Path
-            $property = $json.PSObject.Properties[$Name]
-            if ($null -ne $property) {
-                return [pscustomobject]@{ Exists = $true; Value = $property.Value; Kind = 'DWord'; ReadError = $false }
+            try {
+                $json = Get-ManagedPolicyJson -Path $Target.Path
+                $property = $json.PSObject.Properties[$Name]
+                if ($null -ne $property) {
+                    return [pscustomobject]@{ Exists = $true; Value = $property.Value; Kind = 'DWord'; ReadError = $false }
+                }
+            }
+            catch {
+                # The whole managed policy file is unreadable or not a JSON object. Treat it like an
+                # unreadable registry value so leftover scans and backups skip it instead of aborting
+                # a dry-run or WhatIf preview.
+                return [pscustomobject]@{ Exists = $false; Value = $null; Kind = $null; ReadError = $true }
             }
         }
         return [pscustomobject]@{ Exists = $false; Value = $null; Kind = $null; ReadError = $false }
@@ -295,15 +303,32 @@ function Get-PresentPolicyNames {
     )
 
     $present = New-Object System.Collections.Generic.List[string]
+    $hadReadError = $false
+    $readErrorMessage = ''
     foreach ($policyName in @($PolicyNames)) {
         if ([string]::IsNullOrWhiteSpace([string]$policyName)) {
             continue
         }
 
-        $value = Get-PolicyValue -Target $Target -Name $policyName
-        if ($value.Exists -and -not $value.ReadError) {
-            [void]$present.Add($policyName)
+        try {
+            $value = Get-PolicyValue -Target $Target -Name $policyName
+            if ($value.ReadError) {
+                $hadReadError = $true
+                continue
+            }
+            if ($value.Exists) {
+                [void]$present.Add($policyName)
+            }
         }
+        catch {
+            $hadReadError = $true
+            $readErrorMessage = $_.Exception.Message
+        }
+    }
+
+    if ($hadReadError) {
+        $detail = if ([string]::IsNullOrWhiteSpace($readErrorMessage)) { '' } else { ": $readErrorMessage" }
+        Write-Warning "Could not read existing policies at '$($Target.Path)', so leftover obsolete policies were not checked$detail."
     }
 
     return $present.ToArray()

--- a/src/Reports.ps1
+++ b/src/Reports.ps1
@@ -181,18 +181,30 @@ function Show-DoctorReport {
     }
     $featureRows | Format-Table -AutoSize -Wrap
 
+    $deprecatedPolicyNames = @(Get-DeprecatedPolicyNames -Manifest $Manifest)
+    $obsoleteRows = New-Object System.Collections.Generic.List[object]
     $unknownRows = New-Object System.Collections.Generic.List[object]
     foreach ($report in $reports) {
         foreach ($entry in @($report.Entries)) {
-            if (-not $PolicyDefinitions.ContainsKey([string]$entry.Name)) {
-                [void]$unknownRows.Add([pscustomobject]@{
-                        Scope = $report.Scope
-                        Policy = [string]$entry.Name
-                        Value = $entry.Value
-                        Kind = [string]$entry.Kind
-                    })
+            $entryName = [string]$entry.Name
+            $row = [pscustomobject]@{
+                Scope = $report.Scope
+                Policy = $entryName
+                Value = $entry.Value
+                Kind = [string]$entry.Kind
+            }
+            if ($deprecatedPolicyNames -contains $entryName) {
+                [void]$obsoleteRows.Add($row)
+            }
+            elseif (-not $PolicyDefinitions.ContainsKey($entryName)) {
+                [void]$unknownRows.Add($row)
             }
         }
+    }
+
+    if ($obsoleteRows.Count -gt 0) {
+        Write-Step 'Obsolete leftover policies: detected. Rerun with -Apply to remove them.'
+        $obsoleteRows.ToArray() | Format-Table -AutoSize -Wrap
     }
 
     if ($unknownRows.Count -gt 0) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #34.

Not intentional. Brave now marks `PrivacySandboxPromptEnabled` obsolete in `brave://policy`, and the official ADMX template puts that name (plus `PromotionalTabsEnabled` and `IPFSEnabled`) under `DeprecatedPolicies`. Current main already stopped adding the first two; this change also:

- stops applying `IPFSEnabled`
- removes leftover copies of all three names from the selected policy target on dry-run/apply
- lets `-Doctor` call out those leftovers
- accepts older backups that still contain the deprecated names

Re-run with `-Apply`, restart Brave, then check `brave://policy`. The obsolete entries should be gone.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93a145f6-5a51-4cc1-a85b-967fe1723b80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93a145f6-5a51-4cc1-a85b-967fe1723b80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

